### PR TITLE
Fix mp3 number of samples

### DIFF
--- a/audiofile/__init__.py
+++ b/audiofile/__init__.py
@@ -162,10 +162,7 @@ def duration(file):
     if _file_extension(file) in SNDFORMATS:
         return soundfile.info(file).duration
     else:
-        try:
-            return sox.file_info.duration(file)
-        except sox.core.SoxiError:
-            return samples(file) / sampling_rate(file)
+        return samples(file) / sampling_rate(file)
 
 
 def samples(file):
@@ -182,14 +179,11 @@ def samples(file):
         return int(soundfile.info(file).duration
                    * soundfile.info(file).samplerate)
     else:
-        try:
-            return sox.file_info.num_samples(file)
-        except sox.core.SoxiError:
-            with TemporaryDirectory(prefix='audiofile') as tmpdir:
-                tmpfile = os.path.join(tmpdir, 'tmp.wav')
-                convert_to_wav(file, tmpfile)
-                return int(soundfile.info(tmpfile).duration
-                           * soundfile.info(tmpfile).samplerate)
+        with TemporaryDirectory(prefix='audiofile') as tmpdir:
+            tmpfile = os.path.join(tmpdir, 'tmp.wav')
+            convert_to_wav(file, tmpfile)
+            return int(soundfile.info(tmpfile).duration
+                       * soundfile.info(tmpfile).samplerate)
 
 
 def channels(file):

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -196,6 +196,10 @@ def test_mp3(tmpdir, magnitude, sampling_rate, channels):
         assert sig.ndim == 1
     else:
         assert sig.ndim == 2
+    assert af.channels(mp3_file) == _channels(sig)
+    assert af.sampling_rate(mp3_file) == sampling_rate
+    assert af.samples(mp3_file) == _samples(sig)
+    assert af.duration(mp3_file) == _duration(sig, sampling_rate)
 
 
 def test_movies(tmpdir):


### PR DESCRIPTION
The current implementation was using `sox` for getting the duration and number of samples for MP3 files, if `sox` comes with MP3 support. Unfortunately, `sox` reports slightly longer signals then we actually get after loading them with `audiofile.read`.
This PR introduces corresponding tests to spot the error and fixes it by not using `sox` for `duration` and `samples`.