### PR TITLE
Change url metadata to home-page

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,12 +2,12 @@
 name = audiofile
 author = Hagen Wierstorf
 author-email = hwierstorf@audeering.com
+home-page = https://audiofile.readthedocs.io
 description = Fast reading of all kind of audio files
 long-description = file: README.rst, CHANGELOG.rst
 license = MIT License
 license-file = LICENSE
 keywords = audio tools
-url = https://github.com/audeering/audiofile
 platforms = any
 classifiers =
     Development Status :: 5 - Production/Stable

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -204,7 +204,7 @@ def test_mp3(tmpdir, magnitude, sampling_rate, channels):
 
 
 def test_movies(tmpdir):
-    base_url = 'https://sample-videos.com/video123/'
+    base_url = 'http://sample-videos.com/video123/'
     movies = ['mp4/240/big_buck_bunny_240p_1mb.mp4',
               'mkv/240/big_buck_bunny_240p_1mb.mkv',
               'flv/240/big_buck_bunny_240p_1mb.flv',


### PR DESCRIPTION
* Switched from `url` to `home-page` in `setup.cfg` to be in line with our other packages.
* Switched to the documentation as URL