### PR TITLE
DOC: split install and usage from readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,10 +4,30 @@ audiofile
 
 |tests| |coverage| |docs| |license|
 
-The python package ``audiofile`` provides a meta package to handle all kind of
-audio files under Python with a focus on reading speed.
+The Python package **audiofile** handles all kind of audio files
+with a focus on reading speed.
 
-Documentation: https://audiofile.readthedocs.io/
+It can read and get metadata information
+for all files that are supported by
+ffmpeg_,
+sox_,
+and mediainfo_,
+if those are available on your system.
+In addition, it can create WAV files.
+
+Code example for reading a file:
+
+.. code-block:: python
+
+    import audiofile as af
+
+    signal, sampling_rate = af.read('signal.wav')
+
+
+.. _virtualenv: https://virtualenv.pypa.io/
+.. _ffmpeg: https://www.ffmpeg.org/
+.. _sox: http://sox.sourceforge.net/
+.. _mediainfo: https://mediaarea.net/en/MediaInfo/
 
 .. |tests| image:: https://github.com/audeering/audiofile/workflows/Test/badge.svg
     :target: https://github.com/audeering/audiofile/actions?query=workflow%3ATest
@@ -21,62 +41,3 @@ Documentation: https://audiofile.readthedocs.io/
 .. |license| image:: https://img.shields.io/badge/license-MIT-green.svg
     :target: https://github.com/audeering/audiofile/blob/master/LICENSE
     :alt: audiofile's MIT license
-
-Installation
-============
-
-It is recommended to first create a Python virtual environment using a tool like
-virtualenv_, e.g.
-
-.. code-block:: bash
-
-    virtualenv --python=/usr/bin/python3 --no-site-packages _env
-    source _env/bin/activate
-
-Afterwards install ``audiofile`` with
-
-.. code-block:: bash
-    
-    pip install audiofile
-
-In order to handle all possible audio files, please make sure ffmpeg_ and
-mediainfo_ are installed on your system.
-
-If you want to use Python 2.7 make sure you install the following backports
-package as well:
-
-.. code-block:: bash
-
-    pip install backports.tempfile
-
-.. _virtualenv: https://virtualenv.pypa.io/
-.. _ffmpeg: https://www.ffmpeg.org/
-.. _mediainfo: https://mediaarea.net/en/MediaInfo/
-
-Usage
-=====
-
-Import the package and use it to write or read an audio file, or get information
-about its metadata:
-
-.. code-block:: python
-
-    import numpy as np
-    import audiofile as af
-
-    sampling_rate = 8000  # in Hz
-    noise = np.random.normal(0, 1, sampling_rate)
-    noise /= np.amax(np.abs(noise))
-    af.write('noise.wav', noise, sampling_rate)
-    af.channels('noise.wav')
-    af.duration('noise.wav')
-    sig, fs = af.read('noise.wav')
-
-It should work with every audio file you will work with. WAV, FLAC, and OGG
-files are handled by soundfile_. The reading of all other audio files is managed
-by converting them to a temporary WAV file by pysox_ or ffmpeg_, which means it
-can handle audio from video files as well.
-
-.. _soundfile: https://pysoundfile.readthedocs.io/
-.. _pysox: http://pysox.readthedocs.org/
-.. _ffmpeg: https://www.ffmpeg.org/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,4 @@
-.. audiofile documentation master file
-
 .. include:: ../README.rst
-    :end-line: 24
 
 .. toctree::
     :caption: Getting started

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,3 +1,36 @@
-.. include:: ../README.rst
-    :start-line: 24
-    :end-line: 55
+Installation
+============
+
+:mod:`audiofile` should handle WAV, FLAC, OGG out of the box.
+In order to handle all possible audio files,
+please make sure ffmpeg_,
+sox_,
+and mediainfo_
+are installed on your system,
+e.g.
+
+.. code-block:: bash
+
+    $ sudo apt-get install ffmpeg mediainfo sox
+
+To install :mod:`audiofile` run:
+
+.. code-block:: bash
+
+    $ # Create and activate Python virtual environment, e.g.
+    $ # virtualenv --no-download --python=python3 ${HOME}/.envs/audiofile
+    $ # source ${HOME}/.envs/audiofile/bin/activate
+    $ pip install audiofile
+
+If you want to use Python 2.7
+make sure you install the tempfile backports package as well:
+
+.. code-block:: bash
+
+    pip install backports.tempfile
+
+
+.. _virtualenv: https://virtualenv.pypa.io/
+.. _ffmpeg: https://www.ffmpeg.org/
+.. _sox: http://sox.sourceforge.net/
+.. _mediainfo: https://mediaarea.net/en/MediaInfo/

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,2 +1,29 @@
-.. include:: ../README.rst
-    :start-line: 55
+Usage
+=====
+
+Import the package and use it to write or read an audio file,
+or get information about its metadata:
+
+.. code-block:: python
+
+    import numpy as np
+    import audiofile as af
+
+    sampling_rate = 8000  # in Hz
+    noise = np.random.normal(0, 1, sampling_rate)
+    noise /= np.amax(np.abs(noise))
+    af.write('noise.wav', noise, sampling_rate)
+    af.channels('noise.wav')
+    af.duration('noise.wav')
+    sig, fs = af.read('noise.wav')
+
+It should work with every audio file you will work with.
+WAV, FLAC, and OGG files are handled by soundfile_.
+The reading of all other audio files
+is managed by converting them to a temporary WAV file
+by pysox_ or ffmpeg_,
+which means it can handle audio from video files as well.
+
+.. _soundfile: https://pysoundfile.readthedocs.io/
+.. _pysox: http://pysox.readthedocs.org/
+.. _ffmpeg: https://www.ffmpeg.org/


### PR DESCRIPTION
This simplifies the README and structure of the documentation by moving the installation and usage section out of the README.