### PR TITLE
Add audiofile.bit_depth

### DIFF
--- a/audiofile/__init__.py
+++ b/audiofile/__init__.py
@@ -1,6 +1,7 @@
 """Read, write, and get information about audio files."""
 from audiofile.core.convert import convert_to_wav
 from audiofile.core.info import (
+    bit_depth,
     channels,
     duration,
     samples,

--- a/audiofile/core/info.py
+++ b/audiofile/core/info.py
@@ -1,8 +1,8 @@
 """Read, write, and get information about audio files."""
-from __future__ import division
 import logging
 import os
 import tempfile
+import typing
 
 import soundfile
 import sox
@@ -17,6 +17,50 @@ from audiofile.core.utils import (
 
 # Disable warning outputs of sox as we use it with try
 logging.getLogger('sox').setLevel(logging.CRITICAL)
+
+
+def bit_depth(file: str) -> typing.Optional[int]:
+    r"""Bit depth of audio file.
+
+    For lossy audio files,
+    ``None`` is returned as they have a varying bit depth.
+
+    Args:
+        file: file name of input audio file
+
+    Returns:
+        bit depth of audio file
+
+    """
+    file_type = file_extension(file)
+    if file_type == 'wav':
+        precision_mapping = {
+            'PCM_16': 16,
+            'PCM_24': 24,
+            'PCM_32': 32,
+            'PCM_U8': 8,
+            'FLOAT': 32,
+            'DOUBLE': 64,
+            'ULAW': 8,
+            'ALAW': 8,
+            'IMA_ADPCM': 4,
+            'MS_ADPCM': 4,
+            'GSM610': 16,  # not sure if this could be variable?
+            'G721_32': 4,  # not sure if correct
+        }
+    elif file_type == 'flac':
+        precision_mapping = {
+            'PCM_16': 16,
+            'PCM_24': 24,
+            'PCM_32': 32,
+            'PCM_S8': 8,
+        }
+    if file_extension(file) in ['wav', 'flac']:
+        depth = precision_mapping[soundfile.info(file).subtype]
+    else:
+        depth = None
+
+    return depth
 
 
 def channels(file: str) -> int:

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -142,7 +142,6 @@ def write(
                 f'This will raise an error in version >=0.5.0'
             ),
             category=DeprecationWarning,
-            stacklevel=2,
         )
         bit_depth = backward_mapping[bit_depth]
     if 'precision' in kwargs.keys():
@@ -155,7 +154,6 @@ def write(
                 f'This will raise an error in version >=0.5.0'
             ),
             category=DeprecationWarning,
-            stacklevel=2,
         )
         bit_depth = backward_mapping[_precision]
 

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -3,6 +3,7 @@ import os
 import sys
 import tempfile
 import typing
+import warnings
 
 import numpy as np
 import soundfile
@@ -126,6 +127,36 @@ def write(
 
     """
     file_type = file_extension(file)
+
+    # Backward compatibility between bit_depth and precision
+    backward_mapping = {
+        '16bit': 16,
+        '24bit': 24,
+        '32bit': 32,
+    }
+    if bit_depth in backward_mapping.keys():
+        warnings.warn(
+            (
+                f'Use "{backward_mapping[bit_depth]}" instead of '
+                f'"{bit_depth}" for specifying bit depth'
+            ),
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        bit_depth = backward_mapping[bit_depth]
+    if 'precision' in kwargs.keys():
+        _precision = kwargs.pop('precision')
+        warnings.warn(
+            (
+                f'Use "bit_depth={backward_mapping[_precision]}" '
+                f'instead of "precision={_precision}" '
+                f'for specifying bit depth'
+            ),
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        bit_depth = backward_mapping[_precision]
+
     # Check for allowed precisions
     if file_type == 'wav':
         depth_mapping = {

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -94,7 +94,7 @@ def write(
         file: str,
         signal: np.array,
         sampling_rate: int,
-        precision: str = '16bit',
+        bit_depth: str = 16,
         normalize: bool = False,
         **kwargs,
 ):
@@ -114,10 +114,9 @@ def write(
             The format (WAV, FLAC, OGG) will be inferred from the file name
         signal: audio data to write
         sampling_rate: sample rate of the audio data
-        precision: precision of written file,
-            can be `'8bit'`, `'16bit'`, `'24bit'`
-            for WAV anf FLAC files,
-            and in addition `'32bit'` for WAV files
+        bit_depth: bit depth of written file in bit,
+            can be 8, 16, 24 for WAV and FLAC files,
+            and in addition 32 for WAV files
         normalize: normalize audio data before writing
         kwargs: pass on further arguments to :func:`soundfile.write`
 
@@ -129,26 +128,26 @@ def write(
     file_type = file_extension(file)
     # Check for allowed precisions
     if file_type == 'wav':
-        precision_mapping = {
-            '8bit': 'PCM_U8',
-            '16bit': 'PCM_16',
-            '24bit': 'PCM_24',
-            '32bit': 'PCM_32',
+        depth_mapping = {
+            8: 'PCM_U8',
+            16: 'PCM_16',
+            24: 'PCM_24',
+            32: 'PCM_32',
         }
     elif file_type == 'flac':
-        precision_mapping = {
-            '8bit': 'PCM_S8',
-            '16bit': 'PCM_16',
-            '24bit': 'PCM_24',
+        depth_mapping = {
+            8: 'PCM_S8',
+            16: 'PCM_16',
+            24: 'PCM_24',
         }
     if file_type in ['wav', 'flac']:
-        allowed_precissions = sorted(list(precision_mapping.keys()))
-        if precision not in allowed_precissions:
+        bit_depths = sorted(list(depth_mapping.keys()))
+        if bit_depth not in bit_depths:
             sys.exit(
-                f'"precision" has to be one of '
-                f'{", ".join(allowed_precissions)}.'
+                f'"bit_depth" has to be one of '
+                f'{", ".join([str(b) for b in bit_depths])}.'
             )
-        subtype = precision_mapping[precision]
+        subtype = depth_mapping[bit_depth]
     else:
         subtype = None
     # Check if number of channels is allowed for chosen file type

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -95,7 +95,7 @@ def write(
         file: str,
         signal: np.array,
         sampling_rate: int,
-        bit_depth: str = 16,
+        bit_depth: int = 16,
         normalize: bool = False,
         **kwargs,
 ):

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -138,7 +138,8 @@ def write(
         warnings.warn(
             (
                 f'Use "{backward_mapping[bit_depth]}" instead of '
-                f'"{bit_depth}" for specifying bit depth'
+                f'"{bit_depth}" for specifying bit depth. '
+                f'This will raise an error in version >=0.5.0'
             ),
             category=DeprecationWarning,
             stacklevel=2,
@@ -150,7 +151,8 @@ def write(
             (
                 f'Use "bit_depth={backward_mapping[_precision]}" '
                 f'instead of "precision={_precision}" '
-                f'for specifying bit depth'
+                f'for specifying bit depth. '
+                f'This will raise an error in version >=0.5.0'
             ),
             category=DeprecationWarning,
             stacklevel=2,

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -136,24 +136,18 @@ def write(
     }
     if bit_depth in backward_mapping.keys():
         warnings.warn(
-            (
-                f'Use "{backward_mapping[bit_depth]}" instead of '
-                f'"{bit_depth}" for specifying bit depth. '
-                f'This will raise an error in version >=0.5.0'
-            ),
-            category=DeprecationWarning,
+            f'Use "{backward_mapping[bit_depth]}" instead of '
+            f'"{bit_depth}" for specifying bit depth. '
+            f'This will raise an error in version >=0.5.0'
         )
         bit_depth = backward_mapping[bit_depth]
     if 'precision' in kwargs.keys():
         _precision = kwargs.pop('precision')
         warnings.warn(
-            (
-                f'Use "bit_depth={backward_mapping[_precision]}" '
-                f'instead of "precision={_precision}" '
-                f'for specifying bit depth. '
-                f'This will raise an error in version >=0.5.0'
-            ),
-            category=DeprecationWarning,
+            f'Use "bit_depth={backward_mapping[_precision]}" '
+            f'instead of "precision={_precision}" '
+            f'for specifying bit depth. '
+            f'This will raise an error in version >=0.5.0'
         )
         bit_depth = backward_mapping[_precision]
 

--- a/audiofile/core/utils.py
+++ b/audiofile/core/utils.py
@@ -41,5 +41,20 @@ def run_sox(infile, outfile, offset, duration):
     tfm.build(infile, outfile)
 
 
+MAX_CHANNELS = {
+    'wav': 65535,
+    'ogg': 255,
+    'flac': 8,
+}
+r"""Maximum number of channels per format."""
+
+PRECISIONG = {
+    '8bit': 'PCM_S8',
+    '16bit': 'PCM_16',
+    '24bit': 'PCM_24',
+    '32bit': 'PCM_32',
+}
+r"""Precision as returned by soundfile."""
+
 SNDFORMATS = ['wav', 'flac', 'ogg']
-"""File formats handled by soundfile"""
+r"""File formats handled by soundfile"""

--- a/audiofile/core/utils.py
+++ b/audiofile/core/utils.py
@@ -48,13 +48,5 @@ MAX_CHANNELS = {
 }
 r"""Maximum number of channels per format."""
 
-PRECISIONG = {
-    '8bit': 'PCM_S8',
-    '16bit': 'PCM_16',
-    '24bit': 'PCM_24',
-    '32bit': 'PCM_32',
-}
-r"""Precision as returned by soundfile."""
-
 SNDFORMATS = ['wav', 'flac', 'ogg']
 r"""File formats handled by soundfile"""

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13,10 +13,10 @@ write
 
 .. autofunction:: write
 
-bit_depths
-----------
+bit_depth
+---------
 
-.. autofunction:: bit_depths
+.. autofunction:: bit_depth
 
 channels
 --------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13,6 +13,11 @@ write
 
 .. autofunction:: write
 
+bit_depths
+----------
+
+.. autofunction:: bit_depths
+
 channels
 --------
 

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -94,7 +94,7 @@ def test_deprecated_precision(tmpdir):
     file = str(tmpdir.join('signal-precision.wav'))
     with warnings.catch_warnings(record=True) as w:
         af.write(file, signal, sampling_rate, precision)
-        assert issubclass(w[-1].category, DeprecationWarning)
+        assert issubclass(w[-1].category, UserWarning)
         assert str(w[-1].message) == (
             f'Use "{bit_depth}" instead of '
             f'"{precision}" for specifying bit depth. '
@@ -102,7 +102,7 @@ def test_deprecated_precision(tmpdir):
         )
     with warnings.catch_warnings(record=True) as w:
         af.write(file, signal, sampling_rate, precision=precision)
-        assert issubclass(w[-1].category, DeprecationWarning)
+        assert issubclass(w[-1].category, UserWarning)
         assert str(w[-1].message) == (
             f'Use "bit_depth={bit_depth}" '
             f'instead of "precision={precision}" '

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -2,6 +2,7 @@ from __future__ import division
 import os
 import subprocess
 import socket
+import warnings
 
 import pytest
 import numpy as np
@@ -83,6 +84,29 @@ def _duration(signal, sampling_rate):
 
 def _magnitude(signal):
     return np.max(np.abs(signal))
+
+
+def test_deprecated_precision(tmpdir):
+    sampling_rate = 8000
+    precision = '16bit'
+    bit_depth = 16
+    signal = sine(sampling_rate=sampling_rate)
+    file = str(tmpdir.join('signal-precision.wav'))
+    with warnings.catch_warnings(record=True) as w:
+        af.write(file, signal, sampling_rate, precision)
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert str(w[-1].message) == (
+            f'Use "{bit_depth}" instead of '
+            f'"{precision}" for specifying bit depth'
+        )
+    with warnings.catch_warnings(record=True) as w:
+        af.write(file, signal, sampling_rate, precision=precision)
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert str(w[-1].message) == (
+            f'Use "bit_depth={bit_depth}" '
+            f'instead of "precision={precision}" '
+            f'for specifying bit depth'
+        )
 
 
 @pytest.mark.parametrize("bit_depth", [8, 16, 24, 32])

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -97,7 +97,8 @@ def test_deprecated_precision(tmpdir):
         assert issubclass(w[-1].category, DeprecationWarning)
         assert str(w[-1].message) == (
             f'Use "{bit_depth}" instead of '
-            f'"{precision}" for specifying bit depth'
+            f'"{precision}" for specifying bit depth. '
+            f'This will raise an error in version >=0.5.0'
         )
     with warnings.catch_warnings(record=True) as w:
         af.write(file, signal, sampling_rate, precision=precision)
@@ -105,7 +106,8 @@ def test_deprecated_precision(tmpdir):
         assert str(w[-1].message) == (
             f'Use "bit_depth={bit_depth}" '
             f'instead of "precision={precision}" '
-            f'for specifying bit depth'
+            f'for specifying bit depth. '
+            f'This will raise an error in version >=0.5.0'
         )
 
 


### PR DESCRIPTION
Adds:
* `audiofile.bit_depth`

Fixes:
* `audiofile.write` docstring for precision

It's a little bit unfortunate that I would like to use `bit_depth` as it is more precise what kind of precision we mean, but on the other hand we have the `precision` argument to `audiofile.write`. So, I'm not sure how to bet solve this.

Another question is if we should return an integer or a string. I'm returning now an integer, but I'm not sure if this is correct for `GSM610` and `G721_32`.