### PR TITLE
DOC: add bit_depth to usage

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -48,6 +48,10 @@ Now you can get metadata information on that signal:
 
     af.sampling_rate('noise.flac')
 
+.. jupyter-execute::
+
+    af.bit_depth('noise.flac')
+
 
 Read a file
 -----------


### PR DESCRIPTION
Adds an example to the usage section for the new `bit_depth()` function.