### PR TITLE
Handle pathes with ~ and ..

### DIFF
--- a/audiofile/core/convert.py
+++ b/audiofile/core/convert.py
@@ -2,6 +2,8 @@ import logging
 
 import sox
 
+import audeer
+
 from audiofile.core.utils import (
     run_ffmpeg,
     run_sox,
@@ -32,6 +34,8 @@ def convert_to_wav(
         offset: start reading at offset in seconds
 
     """
+    infile = audeer.safe_path(infile)
+    outfile = audeer.safe_path(outfile)
     try:
         # Convert to WAV file with sox
         run_sox(infile, outfile, offset, duration)

--- a/audiofile/core/info.py
+++ b/audiofile/core/info.py
@@ -7,6 +7,8 @@ import typing
 import soundfile
 import sox
 
+import audeer
+
 from audiofile.core.convert import convert_to_wav
 from audiofile.core.utils import (
     file_extension,
@@ -32,6 +34,7 @@ def bit_depth(file: str) -> typing.Optional[int]:
         bit depth of audio file
 
     """
+    file = audeer.safe_path(file)
     file_type = file_extension(file)
     if file_type == 'wav':
         precision_mapping = {
@@ -73,6 +76,7 @@ def channels(file: str) -> int:
         number of channels in audio file
 
     """
+    file = audeer.safe_path(file)
     if file_extension(file) in SNDFORMATS:
         return soundfile.info(file).channels
     else:
@@ -98,6 +102,7 @@ def duration(file: str) -> float:
         duration in seconds of audio file
 
     """
+    file = audeer.safe_path(file)
     if file_extension(file) in SNDFORMATS:
         return soundfile.info(file).duration
     else:
@@ -119,6 +124,7 @@ def samples(file: str) -> int:
             soundfile.info(file).duration * soundfile.info(file).samplerate
         )
 
+    file = audeer.safe_path(file)
     if file_extension(file) in SNDFORMATS:
         return samples_as_int(file)
     else:
@@ -139,6 +145,7 @@ def sampling_rate(file: str) -> int:
         sampling rate of audio file
 
     """
+    file = audeer.safe_path(file)
     if file_extension(file) in SNDFORMATS:
         return soundfile.info(file).samplerate
     else:

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -8,6 +8,8 @@ import warnings
 import numpy as np
 import soundfile
 
+import audeer
+
 from audiofile.core.convert import convert_to_wav
 from audiofile.core.info import sampling_rate
 from audiofile.core.utils import (
@@ -50,6 +52,7 @@ def read(
         due to a bug in its libsndfile version.
 
     """
+    file = audeer.safe_path(file)
     tmpdir = None
     if file_extension(file) not in SNDFORMATS:
         # Convert file formats not recognized by soundfile to WAV first.
@@ -126,6 +129,7 @@ def write(
         due to a bug in its libsndfile version.
 
     """
+    file = audeer.safe_path(file)
     file_type = file_extension(file)
 
     # Backward compatibility between bit_depth and precision

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
+    audeer
     numpy
     soundfile
     sox


### PR DESCRIPTION
Closes #28.

It now uses `audeer.safe_path` for every function that handles files.
We haven't done this before, because `audeer` was not available at the beginning.