### PR TITLE
Fix audiofile.read for duration=0.0

### DIFF
--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -75,11 +75,11 @@ def read(
                 **kwargs,
             )
     else:
-        if duration or offset > 0:
+        if duration is not None or offset > 0:
             sample_rate = sampling_rate(file)
         if offset > 0:
             offset = np.ceil(offset * sample_rate)  # samples
-        if duration:
+        if duration is not None:
             duration = int(np.ceil(duration * sample_rate) + offset)  # samples
         signal, sample_rate = soundfile.read(
             file,

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -111,6 +111,25 @@ def test_deprecated_precision(tmpdir):
         )
 
 
+@pytest.mark.parametrize('duration', [-1.0, -1, 0, 0.0])
+@pytest.mark.parametrize('offset', [0, 1])
+def test_read(tmpdir, duration, offset):
+    file = str(tmpdir.join('signal.wav'))
+    sampling_rate = 8000
+    signal = sine(
+        duration=0.1,
+        sampling_rate=sampling_rate,
+        channels=1,
+    )
+    af.write(file, signal, sampling_rate)
+    sig, fs = af.read(file, duration=duration, offset=offset)
+    assert sig.shape == (0,)
+    assert fs == sampling_rate
+    sig, fs = af.read(file, always_2d=True, duration=duration, offset=offset)
+    assert sig.shape == (1, 0)
+    assert fs == sampling_rate
+
+
 @pytest.mark.parametrize("bit_depth", [8, 16, 24, 32])
 @pytest.mark.parametrize("duration", [0.01, 0.9999, 2])
 @pytest.mark.parametrize("sampling_rate", [100, 8000, 44100])


### PR DESCRIPTION
Closes #32.

This allows a user to specify `duration=0.0` when using `audiofile.read()`.
It also adds new tests for it.