### PR TITLE
Add dtype as keyword argument to audiofile.read()

### DIFF
--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -24,6 +24,7 @@ def read(
         duration: float = None,
         offset: float = 0,
         always_2d: bool = False,
+        dtype: str = 'float32',
         **kwargs,
 ) -> typing.Tuple[np.array, int]:
     """Read audio file.
@@ -38,6 +39,7 @@ def read(
         offset: start reading at offset in seconds
         always_2d: if `True` it always returns a two-dimensional signal
             even for mono sound files
+        dtype: data type of returned signal
         kwargs: pass on further arguments to :func:`soundfile.read`
 
     Returns:
@@ -70,7 +72,7 @@ def read(
             convert_to_wav(file, tmpfile, offset, duration)
             signal, sample_rate = soundfile.read(
                 tmpfile,
-                dtype='float32',
+                dtype=dtype,
                 always_2d=always_2d,
                 **kwargs,
             )
@@ -85,7 +87,7 @@ def read(
             file,
             start=int(offset),
             stop=duration,
-            dtype='float32',
+            dtype=dtype,
             always_2d=always_2d,
             **kwargs,
         )

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -39,7 +39,12 @@ def read(
         offset: start reading at offset in seconds
         always_2d: if `True` it always returns a two-dimensional signal
             even for mono sound files
-        dtype: data type of returned signal
+        dtype: data type of returned signal,
+            select from
+            ``'float64'``,
+            ``'float32'``,
+            ``'int32'``,
+            ``'int16'``
         kwargs: pass on further arguments to :func:`soundfile.read`
 
     Returns:


### PR DESCRIPTION
Closes #36 

We were indeed setting the `dtype` argument directly for `soundfile` to `float32` without documenting it.
This pull requests adds `dtype` to the arguments of `audiofile.read()` and allows the user to change it.