### PR TITLE
DOC: update TOC and be more verbose on README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,9 +22,15 @@ Code example for reading a file:
 
 .. code-block:: python
 
-    import audiofile as af
+    import audiofile
 
-    signal, sampling_rate = af.read('signal.wav')
+    signal, sampling_rate = audiofile.read('signal.wav')
+
+Under the hood it uses soundfile_ to read the audio files,
+converting non-supported formats first to WAV files.
+The same approach is applied
+when requesting duration for formats that need to be decoded
+to ensure that duration and number of samples match.
 
 
 .. _ffmpeg: https://www.ffmpeg.org/
@@ -34,6 +40,7 @@ Code example for reading a file:
 .. _reading speed: https://audeering.github.io/audiofile/benchmark.html
 .. _sox: http://sox.sourceforge.net/
 .. _virtualenv: https://virtualenv.pypa.io/
+.. _soundfile: https://pysoundfile.readthedocs.io/
 
 .. |tests| image:: https://github.com/audeering/audiofile/workflows/Test/badge.svg
     :target: https://github.com/audeering/audiofile/actions?query=workflow%3ATest

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,11 +7,16 @@
     installation
     usage
     benchmark
-    contributing
-    changelog
 
 .. toctree::
     :caption: API Documentation
     :hidden:
 
     api
+
+.. toctree::
+    :caption: Development
+    :hidden:
+
+    contributing
+    changelog


### PR DESCRIPTION
* Add a development section to the TOC as we do in other projects
* Update code example in README to use `import audiofile` instead of `import audiofile as af`
* Mention `soundfile` in README
* Mention that duration and samples match for decoded files in README

![image](https://user-images.githubusercontent.com/173624/127992684-41570af8-4bdb-4b11-a49e-d528326c0088.png)
