### PR TITLE
DOC: add summary of functions at top of API page

### DIFF
--- a/audiofile/core/info.py
+++ b/audiofile/core/info.py
@@ -110,7 +110,7 @@ def duration(file: str) -> float:
 
 
 def samples(file: str) -> int:
-    """Number of samples in audio file (0 if unavailable).
+    """Number of samples in audio file.
 
     Args:
         file: file name of input audio file

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3,6 +3,17 @@ audiofile
 
 .. automodule:: audiofile
 
+.. autosummary::
+
+    read
+    write
+    bit_depth
+    channels
+    duration
+    samples
+    sampling_rate
+    convert_to_wav
+
 read
 ----
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,6 +32,7 @@ pygments_style = None
 extensions = [
     'jupyter_sphinx',
     'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
     'sphinx.ext.napoleon',  # support for Google-style docstrings
     'sphinx_autodoc_typehints',
     'sphinx_copybutton',


### PR DESCRIPTION
Use the `sphinx.ext.autosummary` extension to show an overview at the top of the API page.

![image](https://user-images.githubusercontent.com/173624/127993339-68fcc00a-613d-4304-9348-bb3735d37229.png)
