### PR TITLE
write() raises RuntimeError instead of SystemExit

### DIFF
--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -128,6 +128,9 @@ def write(
         normalize: normalize audio data before writing
         kwargs: pass on further arguments to :func:`soundfile.write`
 
+    Raises:
+        RuntimeError: for non-supported bit depth or number of channels
+
     """
     file = audeer.safe_path(file)
     file_type = file_extension(file)
@@ -172,7 +175,7 @@ def write(
     if file_type in ['wav', 'flac']:
         bit_depths = sorted(list(depth_mapping.keys()))
         if bit_depth not in bit_depths:
-            sys.exit(
+            raise RuntimeError(
                 f'"bit_depth" has to be one of '
                 f'{", ".join([str(b) for b in bit_depths])}.'
             )
@@ -186,10 +189,12 @@ def write(
         channels = 1
     if channels > MAX_CHANNELS[file_type]:
         if file_type != 'wav':
-            hint = 'Consider using "wav" instead.'
-        sys.exit(
-            'The maximum number of allowed channels '
-            f'for {file_type} is {MAX_CHANNELS[file_type]}. {hint}'
+            hint = " Consider using 'wav' instead."
+        else:
+            hint = ''
+        raise RuntimeError(
+            "The maximum number of allowed channels "
+            f"for '{file_type}' is {MAX_CHANNELS[file_type]}.{hint}"
         )
     if normalize:
         signal = signal / np.max(np.abs(signal))


### PR DESCRIPTION
* Changes `SystemExit` to `RuntimeError` when `audiofile.write()` is called with a non-supported combination of channels and format or a wrong bit depth
* Added the `RuntimeError` to the docs

![image](https://user-images.githubusercontent.com/173624/128014207-c6d5efbb-6b01-4f0b-975d-e6d776d75a1d.png)
