### PR TITLE
Remove deprecated precision argument from write()

### DIFF
--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -135,29 +135,6 @@ def write(
     file = audeer.safe_path(file)
     file_type = file_extension(file)
 
-    # Backward compatibility between bit_depth and precision
-    backward_mapping = {
-        '16bit': 16,
-        '24bit': 24,
-        '32bit': 32,
-    }
-    if bit_depth in backward_mapping.keys():
-        warnings.warn(
-            f'Use "{backward_mapping[bit_depth]}" instead of '
-            f'"{bit_depth}" for specifying bit depth. '
-            f'This will raise an error in version >=0.5.0'
-        )
-        bit_depth = backward_mapping[bit_depth]
-    if 'precision' in kwargs.keys():
-        _precision = kwargs.pop('precision')
-        warnings.warn(
-            f'Use "bit_depth={backward_mapping[_precision]}" '
-            f'instead of "precision={_precision}" '
-            f'for specifying bit depth. '
-            f'This will raise an error in version >=0.5.0'
-        )
-        bit_depth = backward_mapping[_precision]
-
     # Check for allowed precisions
     if file_type == 'wav':
         depth_mapping = {

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -75,31 +75,6 @@ def _magnitude(signal):
     return np.max(np.abs(signal))
 
 
-def test_deprecated_precision(tmpdir):
-    sampling_rate = 8000
-    precision = '16bit'
-    bit_depth = 16
-    signal = sine(sampling_rate=sampling_rate)
-    file = str(tmpdir.join('signal-precision.wav'))
-    with warnings.catch_warnings(record=True) as w:
-        af.write(file, signal, sampling_rate, precision)
-        assert issubclass(w[-1].category, UserWarning)
-        assert str(w[-1].message) == (
-            f'Use "{bit_depth}" instead of '
-            f'"{precision}" for specifying bit depth. '
-            f'This will raise an error in version >=0.5.0'
-        )
-    with warnings.catch_warnings(record=True) as w:
-        af.write(file, signal, sampling_rate, precision=precision)
-        assert issubclass(w[-1].category, UserWarning)
-        assert str(w[-1].message) == (
-            f'Use "bit_depth={bit_depth}" '
-            f'instead of "precision={precision}" '
-            f'for specifying bit depth. '
-            f'This will raise an error in version >=0.5.0'
-        )
-
-
 @pytest.mark.parametrize('duration', [-1.0, -1, 0, 0.0])
 @pytest.mark.parametrize('offset', [0, 1])
 def test_read(tmpdir, duration, offset):


### PR DESCRIPTION
In `audiofile.write()` we allowed for `precision` instead of `bit_depth` and for ung `'16bit'` instead of `16` for the `bit_depth` argument. Both were marked as deprecated and removed in versions >=0.5.0.

As the next release will be 1.0.0, we can remove the deprecated code.