### PR TITLE
Use audeer.file_extension()

### DIFF
--- a/audiofile/core/utils.py
+++ b/audiofile/core/utils.py
@@ -4,10 +4,12 @@ import shlex
 
 import sox
 
+import audeer
+
 
 def file_extension(path):
     """Lower case file extension."""
-    return os.path.splitext(path)[-1][1:].lower()
+    return audeer.file_extension(path).lower()
 
 
 def run(shell_command):


### PR DESCRIPTION
As we need lower case file extensions, we implement `audiofile.core.utils.file_extension()`.
This does now use `audeer.file_extension().lower()`, to make sure it uses our ground truth implementation in `audeer`.