### PR TITLE
Raise RuntimeError for broken files

### DIFF
--- a/audiofile/core/convert.py
+++ b/audiofile/core/convert.py
@@ -35,6 +35,9 @@ def convert_to_wav(
         duration: return only a specified duration in seconds
         offset: start reading at offset in seconds
 
+    Raises:
+        RuntimeError: if ``file`` is broken or not a supproted format
+
     """
     infile = audeer.safe_path(infile)
     outfile = audeer.safe_path(outfile)

--- a/audiofile/core/convert.py
+++ b/audiofile/core/convert.py
@@ -36,7 +36,7 @@ def convert_to_wav(
         offset: start reading at offset in seconds
 
     Raises:
-        RuntimeError: if ``file`` is broken or not a supproted format
+        RuntimeError: if ``file`` is broken or not a supported format
 
     """
     infile = audeer.safe_path(infile)

--- a/audiofile/core/convert.py
+++ b/audiofile/core/convert.py
@@ -1,10 +1,12 @@
 import logging
+import subprocess
 
 import sox
 
 import audeer
 
 from audiofile.core.utils import (
+    broken_file_error,
     run_ffmpeg,
     run_sox,
 )
@@ -40,5 +42,8 @@ def convert_to_wav(
         # Convert to WAV file with sox
         run_sox(infile, outfile, offset, duration)
     except (sox.core.SoxError, sox.core.SoxiError):
-        # Convert to WAV file with ffmpeg
-        run_ffmpeg(infile, outfile, offset, duration)
+        try:
+            # Convert to WAV file with ffmpeg
+            run_ffmpeg(infile, outfile, offset, duration)
+        except subprocess.CalledProcessError:
+            raise RuntimeError(broken_file_error(infile))

--- a/audiofile/core/info.py
+++ b/audiofile/core/info.py
@@ -81,6 +81,7 @@ def channels(file: str) -> int:
         return soundfile.info(file).channels
     else:
         try:
+            print('Running sox')
             return int(sox.file_info.channels(file))
         except sox.core.SoxiError:
             # For MP4 stored and returned number of channels can be different

--- a/audiofile/core/info.py
+++ b/audiofile/core/info.py
@@ -35,7 +35,7 @@ def bit_depth(file: str) -> typing.Optional[int]:
         bit depth of audio file
 
     Raises:
-        RuntimeError: if ``file`` is broken or not a supproted format
+        RuntimeError: if ``file`` is broken or not a supported format
 
     """
     file = audeer.safe_path(file)
@@ -80,7 +80,7 @@ def channels(file: str) -> int:
         number of channels in audio file
 
     Raises:
-        RuntimeError: if ``file`` is broken or not a supproted format
+        RuntimeError: if ``file`` is broken or not a supported format
 
     """
     file = audeer.safe_path(file)
@@ -133,7 +133,7 @@ def duration(file: str, sloppy=False) -> float:
         duration in seconds of audio file
 
     Raises:
-        RuntimeError: if ``file`` is broken or not a supproted format
+        RuntimeError: if ``file`` is broken or not a supported format
 
     """
     file = audeer.safe_path(file)
@@ -167,7 +167,7 @@ def samples(file: str) -> int:
         number of samples in audio file
 
     Raises:
-        RuntimeError: if ``file`` is broken or not a supproted format
+        RuntimeError: if ``file`` is broken or not a supported format
 
     """
     def samples_as_int(file):
@@ -196,7 +196,7 @@ def sampling_rate(file: str) -> int:
         sampling rate of audio file
 
     Raises:
-        RuntimeError: if ``file`` is broken or not a supproted format
+        RuntimeError: if ``file`` is broken or not a supported format
 
     """
     file = audeer.safe_path(file)

--- a/audiofile/core/info.py
+++ b/audiofile/core/info.py
@@ -34,6 +34,9 @@ def bit_depth(file: str) -> typing.Optional[int]:
     Returns:
         bit depth of audio file
 
+    Raises:
+        RuntimeError: if ``file`` is broken or not a supproted format
+
     """
     file = audeer.safe_path(file)
     file_type = file_extension(file)
@@ -75,6 +78,9 @@ def channels(file: str) -> int:
 
     Returns:
         number of channels in audio file
+
+    Raises:
+        RuntimeError: if ``file`` is broken or not a supproted format
 
     """
     file = audeer.safe_path(file)
@@ -126,6 +132,9 @@ def duration(file: str, sloppy=False) -> float:
     Returns:
         duration in seconds of audio file
 
+    Raises:
+        RuntimeError: if ``file`` is broken or not a supproted format
+
     """
     file = audeer.safe_path(file)
     if file_extension(file) in SNDFORMATS:
@@ -157,6 +166,9 @@ def samples(file: str) -> int:
     Returns:
         number of samples in audio file
 
+    Raises:
+        RuntimeError: if ``file`` is broken or not a supproted format
+
     """
     def samples_as_int(file):
         return int(
@@ -182,6 +194,9 @@ def sampling_rate(file: str) -> int:
 
     Returns:
         sampling rate of audio file
+
+    Raises:
+        RuntimeError: if ``file`` is broken or not a supproted format
 
     """
     file = audeer.safe_path(file)

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -55,6 +55,9 @@ def read(
           a one-dimensional array is returned
         * sample rate of the audio file
 
+    Raises:
+        RuntimeError: if ``file`` is broken or not a supproted format
+
     """
     file = audeer.safe_path(file)
     tmpdir = None

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -56,7 +56,7 @@ def read(
         * sample rate of the audio file
 
     Raises:
-        RuntimeError: if ``file`` is broken or not a supproted format
+        RuntimeError: if ``file`` is broken or not a supported format
 
     """
     file = audeer.safe_path(file)

--- a/audiofile/core/utils.py
+++ b/audiofile/core/utils.py
@@ -7,6 +7,26 @@ import sox
 import audeer
 
 
+def broken_file_error(file: str) -> str:
+    r"""Broken file error message.
+
+    If we encounter a broken file,
+    we raise the same error for non SND files
+    as soundfile does for SND files
+
+    Args:
+        file: file name
+
+    Returns:
+        error message
+
+    """
+    return (
+        f'Error opening {file}: '
+        'File contains data in an unknown format.'
+    )
+
+
 def file_extension(path):
     """Lower case file extension."""
     return audeer.file_extension(path).lower()

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -150,7 +150,10 @@ def test_empty_file(empty_file):
 )
 def test_broken_file(extension):
     broken_file = os.path.join(ASSETS_DIR, f'broken.{extension}')
-
+    # Reading file
+    with pytest.raises(RuntimeError, match='data in an unknown format'):
+        af.read(broken_file)
+    # Metadata
     if extension == 'wav':
         with pytest.raises(RuntimeError, match='data in an unknown format'):
             af.bit_depth(broken_file)

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -41,13 +41,13 @@ def empty_file(tmpdir, request):
 
 
 @pytest.fixture(scope='function')
-def broken_file(tmpdir, request):
+def non_audio_file(tmpdir, request):
     """Fixture to generate broken audio files.
 
     The request parameter allows to select the file extension.
 
     """
-    # Create broken audio file
+    # Create empty file to simulate broken/non-audio file
     file_ext = request.param
     broken_file = os.path.join(tmpdir, f'broken-file.{file_ext}')
     open(broken_file, 'w').close()
@@ -163,31 +163,31 @@ def test_empty_file(empty_file):
 
 
 @pytest.mark.parametrize(
-    'broken_file',
+    'non_audio_file',
     ('bin', 'mp3', 'wav'),
     indirect=True,
 )
-def test_broken_file(broken_file):
+def test_broken_file(non_audio_file):
     # Only match the beginning of error message
     # as the default soundfile message differs at the end on macOS
     error_msg = 'Error opening'
     # Reading file
     with pytest.raises(RuntimeError, match=error_msg):
-        af.read(broken_file)
+        af.read(non_audio_file)
     # Metadata
-    if audeer.file_extension(broken_file) == 'wav':
+    if audeer.file_extension(non_audio_file) == 'wav':
         with pytest.raises(RuntimeError, match=error_msg):
-            af.bit_depth(broken_file)
+            af.bit_depth(non_audio_file)
     else:
-        assert af.bit_depth(broken_file) is None
+        assert af.bit_depth(non_audio_file) is None
     with pytest.raises(RuntimeError, match=error_msg):
-        af.channels(broken_file)
+        af.channels(non_audio_file)
     with pytest.raises(RuntimeError, match=error_msg):
-        af.duration(broken_file)
+        af.duration(non_audio_file)
     with pytest.raises(RuntimeError, match=error_msg):
-        af.samples(broken_file)
+        af.samples(non_audio_file)
     with pytest.raises(RuntimeError, match=error_msg):
-        af.sampling_rate(broken_file)
+        af.sampling_rate(non_audio_file)
 
 
 @pytest.mark.parametrize("bit_depth", [8, 16, 24, 32])

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -149,22 +149,25 @@ def test_empty_file(empty_file):
 )
 def test_broken_file(extension):
     broken_file = os.path.join(ASSETS_DIR, f'broken.{extension}')
+    # Only match the beginning of error message
+    # as the default soundfile message differs at the end on macOS
+    error_msg = 'Error opening'
     # Reading file
-    with pytest.raises(RuntimeError, match='data in an unknown format'):
+    with pytest.raises(RuntimeError, match=error_msg):
         af.read(broken_file)
     # Metadata
     if extension == 'wav':
-        with pytest.raises(RuntimeError, match='data in an unknown format'):
+        with pytest.raises(RuntimeError, match=error_msg):
             af.bit_depth(broken_file)
     else:
         assert af.bit_depth(broken_file) is None
-    with pytest.raises(RuntimeError, match='data in an unknown format'):
+    with pytest.raises(RuntimeError, match=error_msg):
         af.channels(broken_file)
-    with pytest.raises(RuntimeError, match='data in an unknown format'):
+    with pytest.raises(RuntimeError, match=error_msg):
         af.duration(broken_file)
-    with pytest.raises(RuntimeError, match='data in an unknown format'):
+    with pytest.raises(RuntimeError, match=error_msg):
         af.samples(broken_file)
-    with pytest.raises(RuntimeError, match='data in an unknown format'):
+    with pytest.raises(RuntimeError, match=error_msg):
         af.sampling_rate(broken_file)
 
 

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -15,7 +15,6 @@ import audiofile as af
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 ASSETS_DIR = os.path.join(SCRIPT_DIR, 'assets')
-SAMPLING_RATE = 16000
 
 
 @pytest.fixture(scope='function')
@@ -27,7 +26,7 @@ def empty_file(request):
     """
 
     tmp_path = tempfile.mktemp('.wav', prefix="empty-audio-")
-    af.write(tmp_path, np.array([[]]), SAMPLING_RATE)
+    af.write(tmp_path, np.array([[]]), 16000)
 
     file_ext = request.param
     ofpath = audeer.replace_file_extension(tmp_path, file_ext)

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -14,8 +14,12 @@ import audiofile as af
 
 
 @pytest.fixture(scope='function')
-def empty_wav_file(request):
-    """fixture to generate to """
+def empty_file(request):
+    """Fixture to generate empty audio files.
+
+    The request parameter allows to change the file extension.
+
+    """
 
     tmp_path = tempfile.mktemp('.wav', prefix="empty-audio-")
     af.write(tmp_path, np.array([[]]), 16000)
@@ -115,12 +119,20 @@ def test_read(tmpdir, duration, offset):
 
 
 @pytest.mark.parametrize(
-    'empty_wav_file', ('.bin', '.wav'), indirect=True)
-def test_read_empty_wav(empty_wav_file):
+    'empty_file',
+    ('bin', 'mp3', 'wav'),
+    indirect=True,
+)
+def test_read_empty_file(empty_file):
     """test that sloppy and nonsloppy have the same return type and value"""
 
-    duration_diligent = af.duration(empty_wav_file, sloppy=False)
-    assert af.duration(empty_wav_file, sloppy=True) == duration_diligent
+    for sloppy in [True, False]:
+        assert af.duration(empty_file, sloppy=sloppy) == 0.0
+
+    assert af.channels(empty_file) == 0
+    assert af.sampling_rate(empty_file) == 0
+    assert af.bit_depth is None
+    assert af.samples == 0
 
 
 @pytest.mark.parametrize("bit_depth", [8, 16, 24, 32])


### PR DESCRIPTION
This extends our error handling for empty and broken files:

* added additional checks for the empty file case
* added tests for broken files

I differentiate between empty and broken files as the empty ones still contain a valid number of channels, samples and sampling rate.

For the broken files we now always raise a `RuntimeError` with the same error message as `soundfile` would raise for broken SND files.

E.g.

```python
>>> open('broken.wav', 'w').close()
>>> audiofile.duration('broken.wav')
...
RuntimeError: Error opening '/home/audeering.local/hwierstorf/git/audeering/audiofile/broken.wav': File contains data in an unknown format.
>>> open('broken.mp3', 'w').close()
>>> audiofile.duration('broken.mp3')
...
RuntimeError: Error opening /home/audeering.local/hwierstorf/git/audeering/audiofile/broken.mp3: File contains data in an unknown format.
```

I extended the docstrings of all relevant functions (which are all besides `audiofile.write()`) with

![image](https://user-images.githubusercontent.com/173624/144033773-1201ccf2-3e53-4d21-82ec-9cfab79e18a0.png)
