### PR TITLE
Update Python package metadata syntax

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,14 +1,14 @@
 [metadata]    
 name = audiofile
 author = Hagen Wierstorf
-author-email = hwierstorf@audeering.com
+author_email = hwierstorf@audeering.com
 description = Fast reading of all kind of audio files
-long-description = file: README.rst, CHANGELOG.rst
+long_description = file: README.rst, CHANGELOG.rst
 license = MIT License
-license-file = LICENSE
+license_file = LICENSE
 keywords = audio tools
 url = https://github.com/audeering/audiofile/
-project-urls =
+project_urls =
     Documentation = https://audeering.github.io/audiofile/
 platforms = any
 classifiers =


### PR DESCRIPTION
Replace deprecated `abc-def` entries with `abc_def` in `setup.cfg`.