### PR TITLE
TST: test for missing files

### DIFF
--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -163,6 +163,24 @@ def test_empty_file(empty_file):
 
 
 @pytest.mark.parametrize(
+    'ext, expected_error',
+    [
+        ('bin', OSError),
+        ('mp3', OSError),
+        ('wav', RuntimeError),
+    ],
+)
+def test_missing_file(ext, expected_error):
+    missing_file = f'missing_file.{ext}'
+    # Reading file
+    with pytest.raises(expected_error):
+        signal, sampling_rate = af.read(missing_file)
+    # Metadata
+    with pytest.raises(expected_error):
+        af.sampling_rate(missing_file)
+
+
+@pytest.mark.parametrize(
     'non_audio_file',
     ('bin', 'mp3', 'wav'),
     indirect=True,


### PR DESCRIPTION
As a first step before tackling #62 I added a test to make sure we raise the expected error messages when the file does not exists. As the main motivation behind `audiofile` was to be as fast as possible, we do not have manual checks for the existence of files, which means the error message raised in the case of a missing file depends on the library that is used for reading the file, leading to different errors for different file types.

As returned error types are part of the API they should not change when we tackle #62.