### PR TITLE
TST: fix installation of sox under Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
     - uses: s-weigand/setup-conda@v1
       with:
         activate-conda: false  # don't switch Python version
-      run: |
+    - run: |
         conda config --add channels conda-forge
         conda config --set channel_priority strict
         conda install sox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,11 +38,11 @@ jobs:
       run: brew install sox ffmpeg mediainfo
       if: matrix.os == 'macOS-latest'
 
-    - name: Windows
-    - uses: s-weigand/setup-conda@v1
+    - name: Prepare Windows
+      uses: s-weigand/setup-conda@v1
       with:
         activate-conda: false  # don't switch Python version
-    - run: |
+      run: |
         conda config --add channels conda-forge
         conda config --set channel_priority strict
         conda install sox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,8 @@ jobs:
         activate-conda: false  # don't switch Python version
 
     - name: Install sox using conda
+      # MP3 support under Linux and macOS, see
+      # https://github.com/conda-forge/sox-feedstock/pull/18
       run: |
         conda config --add channels conda-forge
         conda config --set channel_priority strict

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,9 +49,9 @@ jobs:
         conda config --add channels conda-forge
         conda config --set channel_priority strict
         conda install sox
-        conda install ffmpeg
-        conda install pymediainfo
-        # choco install ffmpeg mediainfo-cli
+        # conda install ffmpeg
+        # conda install pymediainfo
+        choco install ffmpeg mediainfo-cli
       if: matrix.os == 'windows-latest'
 
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,29 +28,29 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Prepare Ubuntu
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y sox libsox-fmt-mp3 ffmpeg mediainfo
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-20.04'
-
-    - name: Prepare OSX
-      run: brew install sox ffmpeg mediainfo
-      if: matrix.os == 'macOS-latest'
-
-    - name: Activate conda on Windows
+    - name: Set up conda
       uses: s-weigand/setup-conda@v1
       with:
         activate-conda: false  # don't switch Python version
-      if: matrix.os == 'windows-latest'
 
-    - name: Prepare Windows
+    - name: Install sox using conda
       run: |
         conda config --add channels conda-forge
         conda config --set channel_priority strict
         conda install sox
-        # conda install ffmpeg
-        # conda install pymediainfo
+
+    - name: Prepare Ubuntu
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ffmpeg mediainfo
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-20.04'
+
+    - name: Prepare OSX
+      run: brew install ffmpeg mediainfo
+      if: matrix.os == 'macOS-latest'
+
+    - name: Prepare Windows
+      run: |
         choco install ffmpeg mediainfo-cli
       if: matrix.os == 'windows-latest'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,8 +39,9 @@ jobs:
       if: matrix.os == 'macOS-latest'
 
     - name: Windows
-      # run: choco install sox.portable ffmpeg mediainfo-cli
     - uses: s-weigand/setup-conda@v1
+      with:
+        activate-conda: false  # don't switch Python version
       run: |
         conda config --add channels conda-forge
         conda config --set channel_priority strict

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,11 @@ jobs:
       if: matrix.os == 'macOS-latest'
 
     - name: Windows
-      run: choco install sox.portable ffmpeg mediainfo-cli
+      # run: choco install sox.portable ffmpeg mediainfo-cli
+      run: |
+        conda config --add channels conda-forge
+        conda config --set channel_priority strict
+        conda install sox
       if: matrix.os == 'windows-latest'
 
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,8 +50,7 @@ jobs:
       if: matrix.os == 'macOS-latest'
 
     - name: Prepare Windows
-      run: |
-        choco install ffmpeg mediainfo-cli
+      run: choco install ffmpeg mediainfo-cli
       if: matrix.os == 'windows-latest'
 
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
 
     - name: Windows
       # run: choco install sox.portable ffmpeg mediainfo-cli
+    - uses: s-weigand/setup-conda@v1
       run: |
         conda config --add channels conda-forge
         conda config --set channel_priority strict

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,14 +38,20 @@ jobs:
       run: brew install sox ffmpeg mediainfo
       if: matrix.os == 'macOS-latest'
 
-    - name: Prepare Windows
+    - name: Activate conda on Windows
       uses: s-weigand/setup-conda@v1
       with:
         activate-conda: false  # don't switch Python version
+      if: matrix.os == 'windows-latest'
+
+    - name: Prepare Windows
       run: |
         conda config --add channels conda-forge
         conda config --set channel_priority strict
         conda install sox
+        conda install ffmpeg
+        conda install pymediainfo
+        # choco install ffmpeg mediainfo-cli
       if: matrix.os == 'windows-latest'
 
     - name: Install dependencies


### PR DESCRIPTION
As we are no longer able to install `sox` under Windows with [chocolatey](https://chocolatey.org) we switch to use `conda` - compare [sox-feedstock](https://github.com/conda-forge/sox-feedstock). `conda` works on all platforms, so I extended the install method for `sox` to Linux and macOS as well.

`mediainfo` is not available under `conda`, only [pymediainfo](https://github.com/sbraz/pymediainfo) - compare [pymediainfo-feedstock](https://github.com/conda-forge/pymediainfo-feedstock) - which does not provide the needed commandline interface of `mediainfo-cli`. Hence I decided to limit `conda` to install `sox` for now.
