### PR TITLE
Allow missing sox binary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
         python-version: [ 3.8 ]
         tasks: [ tests ]
+        sox: [ sox, no-sox ]
         include:
           - os: ubuntu-latest
             python-version: 3.7
@@ -40,6 +41,7 @@ jobs:
       uses: s-weigand/setup-conda@v1
       with:
         activate-conda: false  # don't switch Python version
+      if: matrix.sox == 'sox'
 
     - name: Install sox using conda
       # MP3 support under Linux and macOS, see
@@ -48,12 +50,13 @@ jobs:
         conda config --add channels conda-forge
         conda config --set channel_priority strict
         conda install sox
+      if: matrix.sox == 'sox'
 
-    #- name: Ubuntu - install libsndfile
-    #  run: |
-    #    sudo apt-get update
-    #    sudo apt-get install -y libsndfile1
-    #  if: matrix.os == 'ubuntu-latest' && matrix.sox == 'no-sox'
+    - name: Ubuntu - install libsndfile
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libsndfile1
+      if: matrix.os == 'ubuntu-latest' && matrix.sox == 'no-sox'
 
     - name: Ubuntu - install ffmpeg/mediainfo
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libsndfile1
-      if: matrix.os == 'ubuntu-latest' && matrix.sox == 'no-sox'
+      if: matrix.os == 'ubuntu-latest' && matrix.tasks == 'docs'
 
     - name: Ubuntu - install ffmpeg/mediainfo
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macOS-latest, windows-latest ]
+        os: [ ubuntu-18.04, ubuntu-20.04, macOS-latest, windows-latest ]
         python-version: [3.8]
         include:
           - os: ubuntu-latest
@@ -40,6 +40,7 @@ jobs:
         conda config --add channels conda-forge
         conda config --set channel_priority strict
         conda install sox
+      if: matrix.os != 'ubuntu-18-04'
 
     - name: Prepare Ubuntu
       run: |
@@ -74,9 +75,8 @@ jobs:
 
     - name: Test building documentation
       run: python -m sphinx docs/ docs/_build/ -b html -W
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-18.04'
 
     - name: Check links in documentation
       run: python -m sphinx docs/ docs/_build/ -b linkcheck -W
-      if: matrix.os == 'ubuntu-20.04'
-
+      if: matrix.os == 'ubuntu-18.04'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        # Ubuntu 18.04: build documentation without sox/ffmpeg
         os: [ ubuntu-18.04, ubuntu-20.04, macOS-latest, windows-latest ]
         python-version: [3.8]
         include:
@@ -65,6 +66,7 @@ jobs:
 
     - name: Test with pytest
       run: python -m pytest
+      if: matrix.os != 'ubuntu-18-04'
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           - os: ubuntu-latest
             python-version: 3.8
             tasks: docs
-            sox: no-sox
+            sox: sox
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,10 @@ jobs:
             python-version: 3.9
             tasks: tests
             sox: sox
-          #- os: ubuntu-latest
-          #  python-version: 3.8
-          #  tasks: docs
+          - os: ubuntu-latest
+            python-version: 3.8
+            tasks: docs
+            sox: sox
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,14 +12,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # Ubuntu 18.04: build documentation without sox/ffmpeg
-        os: [ ubuntu-18.04, ubuntu-20.04, macOS-latest, windows-latest ]
-        python-version: [3.8]
+        os: [ ubuntu-latest, macOS-latest, windows-latest ]
+        python-version: [ 3.8 ]
+        tasks: [ tests ]
         include:
           - os: ubuntu-latest
             python-version: 3.7
+            tasks: tests
           - os: ubuntu-latest
             python-version: 3.9
+            tasks: tests
+          - os: ubuntu-20.04
+            python-version: 3.8
+            tasks: docs
 
     steps:
     - uses: actions/checkout@v2
@@ -33,6 +38,7 @@ jobs:
       uses: s-weigand/setup-conda@v1
       with:
         activate-conda: false  # don't switch Python version
+      if: matrix.tasks == 'tests'
 
     - name: Install sox using conda
       # MP3 support under Linux and macOS, see
@@ -41,13 +47,13 @@ jobs:
         conda config --add channels conda-forge
         conda config --set channel_priority strict
         conda install sox
-      if: matrix.os != 'ubuntu-18-04'
+      if: matrix.tasks == 'tests'
 
     - name: Prepare Ubuntu
       run: |
         sudo apt-get update
         sudo apt-get install -y ffmpeg mediainfo
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-latest' && matrix.tasks == 'tests'
 
     - name: Prepare OSX
       run: brew install ffmpeg mediainfo
@@ -66,19 +72,19 @@ jobs:
 
     - name: Test with pytest
       run: python -m pytest
-      if: matrix.os != 'ubuntu-18-04'
+      if: matrix.tasks == 'tests'
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-latest' && matrix.tasks == 'tests'
 
     - name: Test building documentation
       run: python -m sphinx docs/ docs/_build/ -b html -W
-      if: matrix.os == 'ubuntu-18.04'
+      if: matrix.tasks == 'docs'
 
     - name: Check links in documentation
       run: python -m sphinx docs/ docs/_build/ -b linkcheck -W
-      if: matrix.os == 'ubuntu-18.04'
+      if: matrix.tasks == 'docs'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
             python-version: 3.9
             tasks: tests
             sox: true
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             python-version: 3.8
             tasks: docs
             sox: false
@@ -57,7 +57,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libsndfile1
-      if: matrix.sox == false
+      if: matrix.os == 'ubuntu-latest' && matrix.sox == false
 
     - name: Ubuntu - install ffmpeg/mediainfo
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,16 +15,20 @@ jobs:
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
         python-version: [ 3.8 ]
         tasks: [ tests ]
+        sox: [ true, false ]
         include:
           - os: ubuntu-latest
             python-version: 3.7
             tasks: tests
+            sox: true
           - os: ubuntu-latest
             python-version: 3.9
             tasks: tests
+            sox: true
           - os: ubuntu-20.04
             python-version: 3.8
             tasks: docs
+            sox: false
 
     steps:
     - uses: actions/checkout@v2
@@ -38,7 +42,7 @@ jobs:
       uses: s-weigand/setup-conda@v1
       with:
         activate-conda: false  # don't switch Python version
-      if: matrix.tasks == 'tests'
+      if: matrix.sox == true
 
     - name: Install sox using conda
       # MP3 support under Linux and macOS, see
@@ -47,19 +51,25 @@ jobs:
         conda config --add channels conda-forge
         conda config --set channel_priority strict
         conda install sox
-      if: matrix.tasks == 'tests'
+      if: matrix.sox == true
 
-    - name: Prepare Ubuntu
+    - name: Ubuntu: install libsndfile
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libsndfile1
+      if matrix.sox == false
+
+    - name: Ubuntu: install ffmpeg/mediainfo
       run: |
         sudo apt-get update
         sudo apt-get install -y ffmpeg mediainfo
       if: matrix.os == 'ubuntu-latest' && matrix.tasks == 'tests'
 
-    - name: Prepare OSX
+    - name: OSX: install ffmpeg/mediainfo
       run: brew install ffmpeg mediainfo
       if: matrix.os == 'macOS-latest'
 
-    - name: Prepare Windows
+    - name: Windows: install ffmpeg/mediainfo
       run: choco install ffmpeg mediainfo-cli
       if: matrix.os == 'windows-latest'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
         python-version: [ 3.8 ]
         tasks: [ tests ]
-        sox: [ sox, no-sox ]
         include:
           - os: ubuntu-latest
             python-version: 3.7
@@ -28,7 +27,6 @@ jobs:
           - os: ubuntu-latest
             python-version: 3.8
             tasks: docs
-            sox: sox
 
     steps:
     - uses: actions/checkout@v2
@@ -42,7 +40,6 @@ jobs:
       uses: s-weigand/setup-conda@v1
       with:
         activate-conda: false  # don't switch Python version
-      if: matrix.sox == 'sox'
 
     - name: Install sox using conda
       # MP3 support under Linux and macOS, see
@@ -51,13 +48,12 @@ jobs:
         conda config --add channels conda-forge
         conda config --set channel_priority strict
         conda install sox
-      if: matrix.sox == 'sox'
 
-    - name: Ubuntu - install libsndfile
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libsndfile1
-      if: matrix.os == 'ubuntu-latest' && matrix.sox == 'no-sox'
+    #- name: Ubuntu - install libsndfile
+    #  run: |
+    #    sudo apt-get update
+    #    sudo apt-get install -y libsndfile1
+    #  if: matrix.os == 'ubuntu-latest' && matrix.sox == 'no-sox'
 
     - name: Ubuntu - install ffmpeg/mediainfo
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,20 +15,20 @@ jobs:
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
         python-version: [ 3.8 ]
         tasks: [ tests ]
-        sox: [ true, false ]
+        sox: [ sox, no-sox ]
         include:
           - os: ubuntu-latest
             python-version: 3.7
             tasks: tests
-            sox: true
+            sox: sox
           - os: ubuntu-latest
             python-version: 3.9
             tasks: tests
-            sox: true
+            sox: sox
           - os: ubuntu-latest
             python-version: 3.8
             tasks: docs
-            sox: false
+            sox: sox
 
     steps:
     - uses: actions/checkout@v2
@@ -42,7 +42,7 @@ jobs:
       uses: s-weigand/setup-conda@v1
       with:
         activate-conda: false  # don't switch Python version
-      if: matrix.sox == true
+      if: matrix.sox == 'sox'
 
     - name: Install sox using conda
       # MP3 support under Linux and macOS, see
@@ -51,13 +51,13 @@ jobs:
         conda config --add channels conda-forge
         conda config --set channel_priority strict
         conda install sox
-      if: matrix.sox == true
+      if: matrix.sox == 'sox'
 
     - name: Ubuntu - install libsndfile
       run: |
         sudo apt-get update
         sudo apt-get install -y libsndfile1
-      if: matrix.os == 'ubuntu-latest' && matrix.sox == false
+      if: matrix.os == 'ubuntu-latest' && matrix.sox == 'no-sox'
 
     - name: Ubuntu - install ffmpeg/mediainfo
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
         python-version: [ 3.8 ]
         tasks: [ tests ]
-        sox: [ sox, no-sox ]
+        sox: [ sox, no-sox ]  # sox binary present or not
         include:
           - os: ubuntu-latest
             python-version: 3.7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libsndfile1
-      if matrix.sox == false
+      if: matrix.sox == false
 
     - name: Ubuntu - install ffmpeg/mediainfo
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,9 @@ jobs:
             python-version: 3.9
             tasks: tests
             sox: sox
-          - os: ubuntu-latest
-            python-version: 3.8
-            tasks: docs
+          #- os: ubuntu-latest
+          #  python-version: 3.8
+          #  tasks: docs
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           - os: ubuntu-latest
             python-version: 3.8
             tasks: docs
-            sox: sox
+            sox: no-sox
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,23 +53,23 @@ jobs:
         conda install sox
       if: matrix.sox == true
 
-    - name: Ubuntu: install libsndfile
+    - name: Ubuntu - install libsndfile
       run: |
         sudo apt-get update
         sudo apt-get install -y libsndfile1
       if matrix.sox == false
 
-    - name: Ubuntu: install ffmpeg/mediainfo
+    - name: Ubuntu - install ffmpeg/mediainfo
       run: |
         sudo apt-get update
         sudo apt-get install -y ffmpeg mediainfo
       if: matrix.os == 'ubuntu-latest' && matrix.tasks == 'tests'
 
-    - name: OSX: install ffmpeg/mediainfo
+    - name: OSX - install ffmpeg/mediainfo
       run: brew install ffmpeg mediainfo
       if: matrix.os == 'macOS-latest'
 
-    - name: Windows: install ffmpeg/mediainfo
+    - name: Windows - install ffmpeg/mediainfo
       run: choco install ffmpeg mediainfo-cli
       if: matrix.os == 'windows-latest'
 

--- a/audiofile/__init__.py
+++ b/audiofile/__init__.py
@@ -1,5 +1,4 @@
 """Read, write, and get information about audio files."""
-from audiofile.core.convert import convert_to_wav
 from audiofile.core.info import (
     bit_depth,
     channels,
@@ -8,6 +7,7 @@ from audiofile.core.info import (
     sampling_rate,
 )
 from audiofile.core.io import (
+    convert_to_wav,
     read,
     write,
 )

--- a/audiofile/core/convert.py
+++ b/audiofile/core/convert.py
@@ -1,8 +1,6 @@
 import logging
 import subprocess
 
-import sox
-
 import audeer
 
 from audiofile.core.utils import (
@@ -14,6 +12,11 @@ from audiofile.core.utils import (
 
 # Disable warning outputs of sox as we use it with try
 logging.getLogger('sox').setLevel(logging.CRITICAL)
+
+
+# Import sox after disabling warning
+# as it is ok to not have the binary present
+import sox  # pragma: E402
 
 
 def convert_to_wav(

--- a/audiofile/core/convert.py
+++ b/audiofile/core/convert.py
@@ -47,7 +47,7 @@ def convert_to_wav(
     except (
             sox.core.SoxError,
             sox.core.SoxiError,
-            FileNotFoundError,  # sox not installed
+            FileNotFoundError,  # sox binary missing
     ):
         try:
             # Convert to WAV file with ffmpeg

--- a/audiofile/core/convert.py
+++ b/audiofile/core/convert.py
@@ -16,7 +16,7 @@ logging.getLogger('sox').setLevel(logging.CRITICAL)
 
 # Import sox after disabling warning
 # as it is ok to not have the binary present
-import sox  # pragma: E402
+import sox  # noqa: E402
 
 
 def convert_to_wav(

--- a/audiofile/core/convert.py
+++ b/audiofile/core/convert.py
@@ -44,7 +44,11 @@ def convert_to_wav(
     try:
         # Convert to WAV file with sox
         run_sox(infile, outfile, offset, duration)
-    except (sox.core.SoxError, sox.core.SoxiError):
+    except (
+            sox.core.SoxError,
+            sox.core.SoxiError,
+            FileNotFoundError,  # sox not installed
+    ):
         try:
             # Convert to WAV file with ffmpeg
             run_ffmpeg(infile, outfile, offset, duration)

--- a/audiofile/core/convert.py
+++ b/audiofile/core/convert.py
@@ -19,7 +19,7 @@ logging.getLogger('sox').setLevel(logging.CRITICAL)
 import sox  # noqa: E402
 
 
-def convert_to_wav(
+def convert(
         infile: str,
         outfile: str,
         offset: float = 0,
@@ -42,8 +42,6 @@ def convert_to_wav(
         RuntimeError: if ``file`` is broken or not a supported format
 
     """
-    infile = audeer.safe_path(infile)
-    outfile = audeer.safe_path(outfile)
     try:
         # Convert to WAV file with sox
         run_sox(infile, outfile, offset, duration)

--- a/audiofile/core/convert.py
+++ b/audiofile/core/convert.py
@@ -8,7 +8,6 @@ from audiofile.core.utils import (
     run_ffmpeg,
     run_sox,
 )
-from audiofile.core.sox import sox
 
 
 def convert(
@@ -36,6 +35,7 @@ def convert(
     """
     try:
         # Convert to WAV file with sox
+        from audiofile.core.sox import sox
         run_sox(infile, outfile, offset, duration)
     except (
             sox.core.SoxError,

--- a/audiofile/core/convert.py
+++ b/audiofile/core/convert.py
@@ -10,13 +10,15 @@ from audiofile.core.utils import (
 )
 
 
-# Disable warning outputs of sox as we use it with try
-logging.getLogger('sox').setLevel(logging.CRITICAL)
-
-
 # Import sox after disabling warning
 # as it is ok to not have the binary present
+logging.disable(logging.WARNING)
 import sox  # noqa: E402
+logging.disable(logging.NOTSET)
+
+
+# Disable warning outputs of sox as we use it with try
+logging.getLogger('sox').setLevel(logging.CRITICAL)
 
 
 def convert(

--- a/audiofile/core/convert.py
+++ b/audiofile/core/convert.py
@@ -8,17 +8,7 @@ from audiofile.core.utils import (
     run_ffmpeg,
     run_sox,
 )
-
-
-# Import sox after disabling warning
-# as it is ok to not have the binary present
-logging.disable(logging.WARNING)
-import sox  # noqa: E402
-logging.disable(logging.NOTSET)
-
-
-# Disable warning outputs of sox as we use it with try
-logging.getLogger('sox').setLevel(logging.CRITICAL)
+from audiofile.core.sox import sox
 
 
 def convert(

--- a/audiofile/core/info.py
+++ b/audiofile/core/info.py
@@ -15,17 +15,7 @@ from audiofile.core.utils import (
     run,
     SNDFORMATS,
 )
-
-
-# Import sox after disabling warning
-# as it is ok to not have the binary present
-logging.disable(logging.WARNING)
-import sox  # noqa: E402
-logging.disable(logging.NOTSET)
-
-
-# Disable warning outputs of sox as we use it with try
-logging.getLogger('sox').setLevel(logging.CRITICAL)
+from audiofile.core.sox import sox
 
 
 SOX_ERRORS = (

--- a/audiofile/core/info.py
+++ b/audiofile/core/info.py
@@ -15,13 +15,6 @@ from audiofile.core.utils import (
     run,
     SNDFORMATS,
 )
-from audiofile.core.sox import sox
-
-
-SOX_ERRORS = (
-    sox.core.SoxiError,
-    FileNotFoundError,  # sox binary missing
-)
 
 
 def bit_depth(file: str) -> typing.Optional[int]:
@@ -90,6 +83,11 @@ def channels(file: str) -> int:
         return soundfile.info(file).channels
     else:
         try:
+            from audiofile.core.sox import sox
+            SOX_ERRORS = (
+                sox.core.SoxiError,
+                FileNotFoundError,  # sox binary missing
+            )
             return int(sox.file_info.channels(file))
         except SOX_ERRORS:
             # For MP4 stored and returned number of channels can be different
@@ -144,6 +142,11 @@ def duration(file: str, sloppy=False) -> float:
 
     if sloppy:
         try:
+            from audiofile.core.sox import sox
+            SOX_ERRORS = (
+                sox.core.SoxiError,
+                FileNotFoundError,  # sox binary missing
+            )
             duration = sox.file_info.duration(file) or 0.0
         except SOX_ERRORS:
             cmd = f'mediainfo --Inform="Audio;%Duration%" "{file}"'
@@ -204,6 +207,11 @@ def sampling_rate(file: str) -> int:
         return soundfile.info(file).samplerate
     else:
         try:
+            from audiofile.core.sox import sox
+            SOX_ERRORS = (
+                sox.core.SoxiError,
+                FileNotFoundError,  # sox binary missing
+            )
             return int(sox.file_info.sample_rate(file))
         except SOX_ERRORS:
             cmd = f'mediainfo --Inform="Audio;%SamplingRate%" "{file}"'

--- a/audiofile/core/info.py
+++ b/audiofile/core/info.py
@@ -8,7 +8,7 @@ import soundfile
 
 import audeer
 
-from audiofile.core.convert import convert_to_wav
+from audiofile.core.convert import convert
 from audiofile.core.utils import (
     broken_file_error,
     file_extension,
@@ -190,7 +190,7 @@ def samples(file: str) -> int:
         # Always convert to WAV for non SNDFORMATS
         with tempfile.TemporaryDirectory(prefix='audiofile') as tmpdir:
             tmpfile = os.path.join(tmpdir, 'tmp.wav')
-            convert_to_wav(file, tmpfile)
+            convert(file, tmpfile)
             return samples_as_int(tmpfile)
 
 

--- a/audiofile/core/info.py
+++ b/audiofile/core/info.py
@@ -153,16 +153,15 @@ def duration(file: str, sloppy=False) -> float:
     if sloppy:
         try:
             duration = sox.file_info.duration(file)
-            if duration is None:
-                duration = 0.0
-
-            return duration
         except SOX_ERRORS:
             cmd = f'mediainfo --Inform="Audio;%Duration%" "{file}"'
             duration = run(cmd)
             if duration:
                 # Convert to seconds, as mediainfo returns milliseconds
-                return float(duration) / 1000
+                duration = float(duration) / 1000
+        if duration is None:
+            duration = 0.0
+        return duration
 
     return samples(file) / sampling_rate(file)
 

--- a/audiofile/core/info.py
+++ b/audiofile/core/info.py
@@ -152,16 +152,15 @@ def duration(file: str, sloppy=False) -> float:
 
     if sloppy:
         try:
-            duration = sox.file_info.duration(file)
+            duration = sox.file_info.duration(file) or 0.0
         except SOX_ERRORS:
             cmd = f'mediainfo --Inform="Audio;%Duration%" "{file}"'
             duration = run(cmd)
             if duration:
                 # Convert to seconds, as mediainfo returns milliseconds
                 duration = float(duration) / 1000
-        if duration is None:
-            duration = 0.0
-        return duration
+        if duration:
+            return duration
 
     return samples(file) / sampling_rate(file)
 

--- a/audiofile/core/info.py
+++ b/audiofile/core/info.py
@@ -17,13 +17,15 @@ from audiofile.core.utils import (
 )
 
 
-# Disable warning outputs of sox as we use it with try
-logging.getLogger('sox').setLevel(logging.CRITICAL)
-
-
 # Import sox after disabling warning
 # as it is ok to not have the binary present
+logging.disable(logging.WARNING)
 import sox  # noqa: E402
+logging.disable(logging.NOTSET)
+
+
+# Disable warning outputs of sox as we use it with try
+logging.getLogger('sox').setLevel(logging.CRITICAL)
 
 
 SOX_ERRORS = (

--- a/audiofile/core/info.py
+++ b/audiofile/core/info.py
@@ -5,7 +5,6 @@ import tempfile
 import typing
 
 import soundfile
-import sox
 
 import audeer
 
@@ -20,6 +19,11 @@ from audiofile.core.utils import (
 
 # Disable warning outputs of sox as we use it with try
 logging.getLogger('sox').setLevel(logging.CRITICAL)
+
+
+# Import sox after disabling warning
+# as it is ok to not have the binary present
+import sox  # noqa: E402
 
 
 SOX_ERRORS = (

--- a/audiofile/core/info.py
+++ b/audiofile/core/info.py
@@ -22,6 +22,12 @@ from audiofile.core.utils import (
 logging.getLogger('sox').setLevel(logging.CRITICAL)
 
 
+SOX_ERRORS = (
+    sox.core.SoxiError,
+    FileNotFoundError,  # sox binary missing
+)
+
+
 def bit_depth(file: str) -> typing.Optional[int]:
     r"""Bit depth of audio file.
 
@@ -89,7 +95,7 @@ def channels(file: str) -> int:
     else:
         try:
             return int(sox.file_info.channels(file))
-        except sox.core.SoxiError:
+        except SOX_ERRORS:
             # For MP4 stored and returned number of channels can be different
             cmd1 = f'mediainfo --Inform="Audio;%Channel(s)_Original%" "{file}"'
             cmd2 = f'mediainfo --Inform="Audio;%Channel(s)%" "{file}"'
@@ -147,7 +153,7 @@ def duration(file: str, sloppy=False) -> float:
                 duration = 0.0
 
             return duration
-        except sox.core.SoxiError:
+        except SOX_ERRORS:
             cmd = f'mediainfo --Inform="Audio;%Duration%" "{file}"'
             duration = run(cmd)
             if duration:
@@ -205,7 +211,7 @@ def sampling_rate(file: str) -> int:
     else:
         try:
             return int(sox.file_info.sample_rate(file))
-        except sox.core.SoxiError:
+        except SOX_ERRORS:
             cmd = f'mediainfo --Inform="Audio;%SamplingRate%" "{file}"'
             sampling_rate = run(cmd)
             if sampling_rate:

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -10,13 +10,52 @@ import soundfile
 
 import audeer
 
-from audiofile.core.convert import convert_to_wav
-from audiofile.core.info import sampling_rate
+from audiofile.core.convert import convert
+import audiofile.core.info as info
 from audiofile.core.utils import (
     file_extension,
     MAX_CHANNELS,
     SNDFORMATS,
 )
+
+
+def convert_to_wav(
+        infile: str,
+        outfile: str,
+        offset: float = 0,
+        duration: float = None,
+):
+    """Convert any audio/video file to WAV.
+
+    It uses sox or ffmpeg for the conversion.
+    If ``duration`` and/or ``offset`` are specified
+    the resulting WAV file
+    will be shorter accordingly to those values.
+
+    Args:
+        infile: audio/video file name
+        outfile: WAV file name
+        duration: return only a specified duration in seconds
+        offset: start reading at offset in seconds
+
+    Raises:
+        RuntimeError: if ``file`` is broken or not a supported format
+
+    """
+    infile = audeer.safe_path(infile)
+    outfile = audeer.safe_path(outfile)
+    if file_extension(infile) in SNDFORMATS:
+        bit_depth = info.bit_depth(infile)
+        if bit_depth is None:
+            bit_depth = 16
+        signal, sampling_rate = read(
+            infile,
+            offset=offset,
+            duration=duration,
+        )
+        write(outfile, signal, sampling_rate, bit_depth=bit_depth)
+    else:
+        convert(infile, outfile, offset, duration)
 
 
 def read(
@@ -74,8 +113,8 @@ def read(
         # libsndfile see https://github.com/erikd/libsndfile/issues/258.
         with tempfile.TemporaryDirectory(prefix='audiofile') as tmpdir:
             tmpfile = os.path.join(tmpdir, 'tmp.wav')
-            convert_to_wav(file, tmpfile, offset, duration)
-            signal, sample_rate = soundfile.read(
+            convert(file, tmpfile, offset, duration)
+            signal, sampling_rate = soundfile.read(
                 tmpfile,
                 dtype=dtype,
                 always_2d=always_2d,
@@ -83,12 +122,14 @@ def read(
             )
     else:
         if duration is not None or offset > 0:
-            sample_rate = sampling_rate(file)
+            sampling_rate = info.sampling_rate(file)
         if offset > 0:
-            offset = np.ceil(offset * sample_rate)  # samples
+            offset = np.ceil(offset * sampling_rate)  # samples
         if duration is not None:
-            duration = int(np.ceil(duration * sample_rate) + offset)  # samples
-        signal, sample_rate = soundfile.read(
+            duration = int(
+                np.ceil(duration * sampling_rate) + offset
+            )  # samples
+        signal, sampling_rate = soundfile.read(
             file,
             start=int(offset),
             stop=duration,
@@ -98,7 +139,7 @@ def read(
         )
     # [samples, channels] => [channels, samples]
     signal = signal.T
-    return signal, sample_rate
+    return signal, sampling_rate
 
 
 def write(

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -27,7 +27,8 @@ def convert_to_wav(
 ):
     """Convert any audio/video file to WAV.
 
-    It uses sox or ffmpeg for the conversion.
+    It uses soundfile for converting WAV, FLAC, OGG files,
+    and sox or ffmpeg for converting all other files.
     If ``duration`` and/or ``offset`` are specified
     the resulting WAV file
     will be shorter accordingly to those values.

--- a/audiofile/core/sox.py
+++ b/audiofile/core/sox.py
@@ -1,0 +1,16 @@
+import contextlib
+import logging
+
+
+"""Import sox without warnings.
+
+We can import sox,
+even if its binaries are missing.
+As this is valid behavior in audiofile,
+we surpress all related output warnings
+during import.
+
+"""
+with contextlib.redirect_stderr(None):
+    import sox
+logging.getLogger('sox').setLevel(logging.CRITICAL)

--- a/audiofile/core/utils.py
+++ b/audiofile/core/utils.py
@@ -6,13 +6,15 @@ import shlex
 import audeer
 
 
-# Disable warning outputs of sox as we use it with try
-logging.getLogger('sox').setLevel(logging.CRITICAL)
-
-
 # Import sox after disabling warning
 # as it is ok to not have the binary present
+logging.disable(logging.WARNING)
 import sox  # noqa: E402
+logging.disable(logging.NOTSET)
+
+
+# Disable warning outputs of sox as we use it with try
+logging.getLogger('sox').setLevel(logging.CRITICAL)
 
 
 def broken_file_error(file: str) -> str:

--- a/audiofile/core/utils.py
+++ b/audiofile/core/utils.py
@@ -2,9 +2,16 @@ import os
 import subprocess
 import shlex
 
-import sox
-
 import audeer
+
+
+# Disable warning outputs of sox as we use it with try
+logging.getLogger('sox').setLevel(logging.CRITICAL)
+
+
+# Import sox after disabling warning
+# as it is ok to not have the binary present
+import sox  # noqa: E402
 
 
 def broken_file_error(file: str) -> str:

--- a/audiofile/core/utils.py
+++ b/audiofile/core/utils.py
@@ -4,8 +4,6 @@ import shlex
 
 import audeer
 
-from audiofile.core.sox import sox
-
 
 def broken_file_error(file: str) -> str:
     r"""Broken file error message.
@@ -55,6 +53,7 @@ def run_ffmpeg(infile, outfile, offset, duration):
 
 def run_sox(infile, outfile, offset, duration):
     """Convert audio file to WAV file."""
+    from audiofile.core.sox import sox
     tfm = sox.Transformer()
     if duration:
         tfm.trim(offset, duration + offset)

--- a/audiofile/core/utils.py
+++ b/audiofile/core/utils.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import subprocess
 import shlex

--- a/audiofile/core/utils.py
+++ b/audiofile/core/utils.py
@@ -1,20 +1,10 @@
-import logging
 import os
 import subprocess
 import shlex
 
 import audeer
 
-
-# Import sox after disabling warning
-# as it is ok to not have the binary present
-logging.disable(logging.WARNING)
-import sox  # noqa: E402
-logging.disable(logging.NOTSET)
-
-
-# Disable warning outputs of sox as we use it with try
-logging.getLogger('sox').setLevel(logging.CRITICAL)
+from audiofile.core.sox import sox
 
 
 def broken_file_error(file: str) -> str:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,11 +3,11 @@ Installation
 
 :mod:`audiofile` supports WAV, FLAC, OGG out of the box.
 In order to handle all possible audio files,
-please make sure ffmpeg_,
-sox_
-(with MP3 support for best performance),
+please make sure ffmpeg_
 and mediainfo_
-are installed on your system,
+are installed on your system.
+For faster access of MP3 files,
+please install sox_ with MP3 bindings as well,
 e.g.
 
 .. code-block:: bash

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -411,11 +411,6 @@ def test_file_type(tmpdir, file_type, magnitude, sampling_rate, channels):
 @pytest.mark.parametrize('magnitude', [0.01])
 def test_mp3(tmpdir, magnitude, sampling_rate, channels):
 
-    # Currently we are not able to setup the Windows runner with MP3 support
-    # https://github.com/audeering/audiofile/issues/51
-    if sys.platform == 'win32':
-        return
-
     signal = sine(magnitude=magnitude,
                   sampling_rate=sampling_rate,
                   channels=channels)

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -1,5 +1,6 @@
 from __future__ import division
 import os
+import platform
 import shutil
 import subprocess
 import sys
@@ -73,10 +74,10 @@ def hide_sox(tmpdir, request):
         path = audeer.mkdir(os.path.join(tmpdir, 'bin'))
         for program in ['ffmpeg', 'mediainfo']:
             command = shutil.which(program)
-            if sys.platform == 'win32':
-                shutil.copyfile(command, os.path.join(path, program))
-            else:
-                os.symlink(command, os.path.join(path, program))
+            local_command = os.path.join(path, program)
+            if platform.system() == 'Windows':
+                local_command += '.EXE'
+            os.symlink(command, local_command)
         os.environ['PATH'] = path
 
     yield

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -73,7 +73,10 @@ def hide_sox(tmpdir, request):
         path = audeer.mkdir(os.path.join(tmpdir, 'bin'))
         for program in ['ffmpeg', 'mediainfo']:
             command = shutil.which(program)
-            os.symlink(command, os.path.join(path, program))
+            if sys.platform == 'win32':
+                shutil.copyfile(command, os.path.join(path, program))
+            else:
+                os.symlink(command, os.path.join(path, program))
         os.environ['PATH'] = path
 
     yield

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -268,10 +268,10 @@ def test_broken_file(hide_sox, non_audio_file):
 )
 def test_missing_binaries(hide_system_path, empty_file):
     # Reading file
-    with pytest.raises(FileNotFoundError, match='ffmpeg'):
+    with pytest.raises(FileNotFoundError):
         signal, sampling_rate = af.read(empty_file)
     # Metadata
-    with pytest.raises(FileNotFoundError, match='mediainfo'):
+    with pytest.raises(FileNotFoundError):
         af.sampling_rate(empty_file)
 
 

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -391,12 +391,6 @@ def test_mp3(tmpdir, magnitude, sampling_rate, channels):
     )
     assert audeer.file_extension(mp3_file) == 'mp3'
     sig, fs = af.read(mp3_file)
-    assert_allclose(
-        _magnitude(sig),
-        magnitude,
-        rtol=0,
-        atol=tolerance(16),
-    )
     assert fs == sampling_rate
     assert _channels(sig) == channels
     if channels == 1:

--- a/tests/test_symlink.py
+++ b/tests/test_symlink.py
@@ -9,5 +9,8 @@ def test_symlinks(tmpdir):
     path = audeer.mkdir(os.path.join(tmpdir, 'bin'))
     command = shutil.which(program)
     assert os.path.exists(command)
-    os.symlink(command, os.path.join(path, program))
-    assert os.path.exists(os.path.join(path, program))
+    local_command = os.path.join(path, program)
+    os.symlink(command, local_command)
+    assert os.path.exists(local_command)
+    os.environ['PATH'] = path
+    assert shutil.which(program) == local_command

--- a/tests/test_symlink.py
+++ b/tests/test_symlink.py
@@ -10,8 +10,8 @@ def test_symlinks(tmpdir):
     command = shutil.which(program)
     assert os.path.exists(command)
     local_command = os.path.join(path, program)
-    # os.symlink(command, local_command)
-    shutil.copyfile(command, local_command)
+    os.symlink(command, local_command)
+    # shutil.copyfile(command, local_command)
     assert os.path.exists(local_command)
     print(os.environ['PATH'])
     os.environ['PATH'] = path

--- a/tests/test_symlink.py
+++ b/tests/test_symlink.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import shutil
 
 import audeer
@@ -8,6 +9,8 @@ def test_symlinks(tmpdir):
     program = 'ffmpeg'
     path = audeer.mkdir(os.path.join(tmpdir, 'bin'))
     command = shutil.which(program)
+    if platform.system() == 'Windows':
+        command += '.exe'
     assert os.path.exists(command)
     local_command = os.path.join(path, program)
     os.symlink(command, local_command)

--- a/tests/test_symlink.py
+++ b/tests/test_symlink.py
@@ -9,13 +9,13 @@ def test_symlinks(tmpdir):
     program = 'ffmpeg'
     path = audeer.mkdir(os.path.join(tmpdir, 'bin'))
     command = shutil.which(program)
-    if platform.system() == 'Windows':
-        command += '.exe'
+    print(command)
     assert os.path.exists(command)
     local_command = os.path.join(path, program)
     os.symlink(command, local_command)
     # shutil.copyfile(command, local_command)
     assert os.path.exists(local_command)
+    print(local_command)
     print(os.environ['PATH'])
     os.environ['PATH'] = path
     print(os.environ['PATH'])

--- a/tests/test_symlink.py
+++ b/tests/test_symlink.py
@@ -2,23 +2,36 @@ import os
 import platform
 import shutil
 
+import pytest
+
 import audeer
 
 
-def test_symlinks(tmpdir):
-    program = 'ffmpeg'
+@pytest.fixture(scope='function')
+def restore_system_path():
+    """Fixture to hide system path in test."""
+    current_path = os.environ['PATH']
+
+    yield
+
+    os.environ['PATH'] = current_path
+
+
+@pytest.mark.parametrize(
+    'program',
+    [
+        'ffmpeg',
+        'mediainfo',
+    ],
+)
+def test_symlinks(tmpdir, restore_system_path, program):
     path = audeer.mkdir(os.path.join(tmpdir, 'bin'))
     command = shutil.which(program)
-    print(command)
     assert os.path.exists(command)
     local_command = os.path.join(path, program)
     if platform.system() == 'Windows':
         local_command += '.EXE'
     os.symlink(command, local_command)
-    # shutil.copyfile(command, local_command)
     assert os.path.exists(local_command)
-    print(local_command)
-    print(os.environ['PATH'])
     os.environ['PATH'] = path
-    print(os.environ['PATH'])
     assert shutil.which(program) == local_command

--- a/tests/test_symlink.py
+++ b/tests/test_symlink.py
@@ -10,7 +10,10 @@ def test_symlinks(tmpdir):
     command = shutil.which(program)
     assert os.path.exists(command)
     local_command = os.path.join(path, program)
-    os.symlink(command, local_command)
+    # os.symlink(command, local_command)
+    shutil.copyfile(command, local_command)
     assert os.path.exists(local_command)
+    print(os.environ['PATH'])
     os.environ['PATH'] = path
+    print(os.environ['PATH'])
     assert shutil.which(program) == local_command

--- a/tests/test_symlink.py
+++ b/tests/test_symlink.py
@@ -12,6 +12,8 @@ def test_symlinks(tmpdir):
     print(command)
     assert os.path.exists(command)
     local_command = os.path.join(path, program)
+    if platform.system() == 'Windows':
+        local_command += '.EXE'
     os.symlink(command, local_command)
     # shutil.copyfile(command, local_command)
     assert os.path.exists(local_command)

--- a/tests/test_symlink.py
+++ b/tests/test_symlink.py
@@ -1,0 +1,13 @@
+import os
+import shutil
+
+import audeer
+
+
+def test_symlinks(tmpdir):
+    program = 'ffmpeg'
+    path = audeer.mkdir(os.path.join(tmpdir, 'bin'))
+    command = shutil.which(program)
+    assert os.path.exists(command)
+    os.symlink(command, os.path.join(path, program))
+    assert os.path.exists(os.path.join(path, program))


### PR DESCRIPTION
This introduces the following changes:

* allows the `sox` binary to be missing
* extends the tests on Github to run with and without installed `sox` binaries
* installs `sox` with `conda` on the Github runners
* fix `audiofile.convert_to_wav()` to use `soundfile` instead of `sox` when converting SND files (WAV, OGG, FLAC)
* test also MP3 files under Windows
* execute all Linux tests under `ubuntu-latest`
* build the documentation without `sox`, `ffmpeg`, `mediafile` installed
* remove the usage of `sox` in the tests (use `soundfile` instead)
* add a test for error message when `ffmpeg` and `mediainfo` are missing
* import sox only inside `try` statement to suppress stdout warning message 

The docstring of `audiofile.convert_to_wav()` is updated accordingly:

![image](https://user-images.githubusercontent.com/173624/162966761-cbce8ac8-e937-4fd7-8f5e-422a5373a627.png)
