### PR TITLE
TST: separate test for building documentation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,13 +12,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macOS-latest, windows-latest ]
+        os: [ ubuntu-latest, macOS-latest, windows-latest ]
         python-version: [3.8]
+        tasks: [ tests ]
         include:
           - os: ubuntu-latest
             python-version: 3.7
+            tasks: tests
           - os: ubuntu-latest
             python-version: 3.9
+            tasks: tests
+          - os: ubuntu-latest
+            python-version: 3.8
+            tasks: docs
 
     steps:
     - uses: actions/checkout@v2
@@ -45,7 +51,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y ffmpeg mediainfo
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-latest'
 
     - name: Prepare OSX
       run: brew install ffmpeg mediainfo
@@ -55,28 +61,37 @@ jobs:
       run: choco install ffmpeg mediainfo-cli
       if: matrix.os == 'windows-latest'
 
-    - name: Install dependencies
+    - name: Install package
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install -r docs/requirements.txt
+
+    # TESTS
+    - name: Install tests requirements
         pip install -r tests/requirements.txt
+      if: matrix.tasks == 'tests'
 
     - name: Test with pytest
       run: python -m pytest
+      if: matrix.tasks == 'tests'
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.tasks == 'tests' && matrix.os == 'ubuntu-latest'
+
+    # DOCS
+    - name: Install docs requirements
+      run: |
+        pip install -r docs/requirements.txt
+      if: matrix.tasks == 'docs'
 
     - name: Test building documentation
       run: python -m sphinx docs/ docs/_build/ -b html -W
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.tasks == 'docs'
 
     - name: Check links in documentation
       run: python -m sphinx docs/ docs/_build/ -b linkcheck -W
-      if: matrix.os == 'ubuntu-20.04'
-
+      if: matrix.tasks == 'docs'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
 
     # TESTS
     - name: Install tests requirements
-        pip install -r tests/requirements.txt
+      run: pip install -r tests/requirements.txt
       if: matrix.tasks == 'tests'
 
     - name: Test with pytest
@@ -84,8 +84,7 @@ jobs:
 
     # DOCS
     - name: Install docs requirements
-      run: |
-        pip install -r docs/requirements.txt
+      run: pip install -r docs/requirements.txt
       if: matrix.tasks == 'docs'
 
     - name: Test building documentation

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
-        python-version: [3.8]
+        python-version: [ 3.8 ]
         tasks: [ tests ]
         include:
           - os: ubuntu-latest


### PR DESCRIPTION
This introduces the key `tasks` to the matrix definition in `.github/workflows/test.yml` to make it easier to separate tests for code and documentation. This has the advantage that we can use the same Ubuntu version in tests and docs as we now can use the `tasks` key to check if we should build the docs. I also updated the code that only the task specific requirements are installed.

The tasks key is then also visible when the Actions are executed:

![image](https://user-images.githubusercontent.com/173624/163118427-e49ea00c-06fb-453d-bb36-8329dd6b48ba.png)
