### PR TITLE
Make sure we raise RuntimeError for broken files

### DIFF
--- a/audiofile/core/convert.py
+++ b/audiofile/core/convert.py
@@ -36,7 +36,8 @@ def convert_to_wav(
         offset: start reading at offset in seconds
 
     Raises:
-        RuntimeError: if ``file`` is broken or not a supported format
+        RuntimeError: if ``file`` is missing,
+            broken or not a supported format
 
     """
     infile = audeer.safe_path(infile)
@@ -50,3 +51,5 @@ def convert_to_wav(
             run_ffmpeg(infile, outfile, offset, duration)
         except subprocess.CalledProcessError:
             raise RuntimeError(broken_file_error(infile))
+    except OSError:
+        raise RuntimeError(broken_file_error(infile))

--- a/audiofile/core/convert.py
+++ b/audiofile/core/convert.py
@@ -37,7 +37,7 @@ def convert_to_wav(
 
     Raises:
         RuntimeError: if ``file`` is missing,
-            broken or not a supported format
+            broken or format is not supported
 
     """
     infile = audeer.safe_path(infile)

--- a/audiofile/core/info.py
+++ b/audiofile/core/info.py
@@ -36,7 +36,7 @@ def bit_depth(file: str) -> typing.Optional[int]:
 
     Raises:
         RuntimeError: if ``file`` is missing,
-            broken or not a supported format
+            broken or format is not supported
 
     """
     file = audeer.safe_path(file)
@@ -82,7 +82,7 @@ def channels(file: str) -> int:
 
     Raises:
         RuntimeError: if ``file`` is missing,
-            broken or not a supported format
+            broken or format is not supported
 
     """
     file = audeer.safe_path(file)
@@ -138,7 +138,7 @@ def duration(file: str, sloppy=False) -> float:
 
     Raises:
         RuntimeError: if ``file`` is missing,
-            broken or not a supported format
+            broken or format is not supported
 
     """
     file = audeer.safe_path(file)
@@ -174,7 +174,7 @@ def samples(file: str) -> int:
 
     Raises:
         RuntimeError: if ``file`` is missing,
-            broken or not a supported format
+            broken or format is not supported
 
     """
     def samples_as_int(file):
@@ -204,7 +204,7 @@ def sampling_rate(file: str) -> int:
 
     Raises:
         RuntimeError: if ``file`` is missing,
-            broken or not a supported format
+            broken or format is not supported
 
     """
     file = audeer.safe_path(file)

--- a/audiofile/core/info.py
+++ b/audiofile/core/info.py
@@ -35,7 +35,8 @@ def bit_depth(file: str) -> typing.Optional[int]:
         bit depth of audio file
 
     Raises:
-        RuntimeError: if ``file`` is broken or not a supported format
+        RuntimeError: if ``file`` is missing,
+            broken or not a supported format
 
     """
     file = audeer.safe_path(file)
@@ -80,7 +81,8 @@ def channels(file: str) -> int:
         number of channels in audio file
 
     Raises:
-        RuntimeError: if ``file`` is broken or not a supported format
+        RuntimeError: if ``file`` is missing,
+            broken or not a supported format
 
     """
     file = audeer.safe_path(file)
@@ -100,6 +102,8 @@ def channels(file: str) -> int:
                     return int(run(cmd2))
                 except ValueError:
                     raise RuntimeError(broken_file_error(file))
+        except OSError:
+            raise RuntimeError(broken_file_error(file))
 
 
 def duration(file: str, sloppy=False) -> float:
@@ -133,7 +137,8 @@ def duration(file: str, sloppy=False) -> float:
         duration in seconds of audio file
 
     Raises:
-        RuntimeError: if ``file`` is broken or not a supported format
+        RuntimeError: if ``file`` is missing,
+            broken or not a supported format
 
     """
     file = audeer.safe_path(file)
@@ -153,7 +158,8 @@ def duration(file: str, sloppy=False) -> float:
             if duration:
                 # Convert to seconds, as mediainfo returns milliseconds
                 return float(duration) / 1000
-
+        except OSError:
+            raise RuntimeError(broken_file_error(file))
     return samples(file) / sampling_rate(file)
 
 
@@ -167,7 +173,8 @@ def samples(file: str) -> int:
         number of samples in audio file
 
     Raises:
-        RuntimeError: if ``file`` is broken or not a supported format
+        RuntimeError: if ``file`` is missing,
+            broken or not a supported format
 
     """
     def samples_as_int(file):
@@ -196,7 +203,8 @@ def sampling_rate(file: str) -> int:
         sampling rate of audio file
 
     Raises:
-        RuntimeError: if ``file`` is broken or not a supported format
+        RuntimeError: if ``file`` is missing,
+            broken or not a supported format
 
     """
     file = audeer.safe_path(file)
@@ -212,3 +220,5 @@ def sampling_rate(file: str) -> int:
                 return int(sampling_rate)
             else:
                 raise RuntimeError(broken_file_error(file))
+        except OSError:
+            raise RuntimeError(broken_file_error(file))

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -56,7 +56,8 @@ def read(
         * sample rate of the audio file
 
     Raises:
-        RuntimeError: if ``file`` is broken or not a supported format
+        RuntimeError: if ``file`` is missing,
+            broken or not a supported format
 
     """
     file = audeer.safe_path(file)

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -57,7 +57,7 @@ def read(
 
     Raises:
         RuntimeError: if ``file`` is missing,
-            broken or not a supported format
+            broken or format is not supported
 
     """
     file = audeer.safe_path(file)


### PR DESCRIPTION
Before in the docs we always stated:

![image](https://user-images.githubusercontent.com/173624/163130719-a591cba2-9b05-41d4-b6bd-d5f9141645cf.png)

I updated this to

![image](https://user-images.githubusercontent.com/173624/163137776-7a8a82ed-611f-4e2a-a2b5-4af18cbae0a9.png)

in all relevbant docstrings.

We did already tested for missing files in the tests, but before, `sox` and `ffmpeg`/`mediainfo` were raising `OSError` when a file was missing. Some days ago I voted not to change this, but as we never stated in the documentation that they should raise an `OSError` I think it makes more sense to fix this and always return the desired `RuntimeError` as done in this pull request.

In addition, I added all the relevant tests for `audiofile.convert_to_wav()` as well, as we didn't test the error there before.