### PR TITLE
Allow sox binary to be missing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,17 +53,23 @@ jobs:
         conda install sox
       if: matrix.sox == 'sox'
 
-    - name: Prepare Ubuntu
+    - name: Ubuntu - install libsndfile
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libsndfile1
+      if: matrix.sox == 'no-sox'
+
+    - name: Ubuntu - install ffmpeg/mediainfo
       run: |
         sudo apt-get update
         sudo apt-get install -y ffmpeg mediainfo
       if: matrix.os == 'ubuntu-latest'
 
-    - name: Prepare OSX
+    - name: OSX - install ffmpeg/mediainfo
       run: brew install ffmpeg mediainfo
       if: matrix.os == 'macOS-latest'
 
-    - name: Prepare Windows
+    - name: Windows - install ffmpeg/mediainfo
       run: choco install ffmpeg mediainfo-cli
       if: matrix.os == 'windows-latest'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,16 +15,20 @@ jobs:
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
         python-version: [ 3.8 ]
         tasks: [ tests ]
+        sox: [ sox, no-sox ]  # sox binary present or not
         include:
           - os: ubuntu-latest
             python-version: 3.7
             tasks: tests
+            sox: sox
           - os: ubuntu-latest
             python-version: 3.9
             tasks: tests
+            sox: sox
           - os: ubuntu-latest
             python-version: 3.8
             tasks: docs
+            sox: sox
 
     steps:
     - uses: actions/checkout@v2
@@ -38,6 +42,7 @@ jobs:
       uses: s-weigand/setup-conda@v1
       with:
         activate-conda: false  # don't switch Python version
+      if: matrix.sox == 'sox'
 
     - name: Install sox using conda
       # MP3 support under Linux and macOS, see
@@ -46,6 +51,7 @@ jobs:
         conda config --add channels conda-forge
         conda config --set channel_priority strict
         conda install sox
+      if: matrix.sox == 'sox'
 
     - name: Prepare Ubuntu
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           - os: ubuntu-latest
             python-version: 3.8
             tasks: docs
-            sox: sox
+            sox: no-sox
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libsndfile1
-      if: matrix.sox == 'no-sox'
+      if: matrix.os == 'ubuntu-latest' && matrix.sox == 'no-sox'
 
     - name: Ubuntu - install ffmpeg/mediainfo
       run: |

--- a/audiofile/core/convert.py
+++ b/audiofile/core/convert.py
@@ -1,8 +1,6 @@
 import logging
 import subprocess
 
-import sox
-
 import audeer
 
 from audiofile.core.utils import (
@@ -10,10 +8,6 @@ from audiofile.core.utils import (
     run_ffmpeg,
     run_sox,
 )
-
-
-# Disable warning outputs of sox as we use it with try
-logging.getLogger('sox').setLevel(logging.CRITICAL)
 
 
 def convert(
@@ -42,8 +36,9 @@ def convert(
     """
     try:
         # Convert to WAV file with sox
+        from audiofile.core.sox import SOX_ERRORS
         run_sox(infile, outfile, offset, duration)
-    except (sox.core.SoxError, sox.core.SoxiError):
+    except SOX_ERRORS:
         try:
             # Convert to WAV file with ffmpeg
             run_ffmpeg(infile, outfile, offset, duration)

--- a/audiofile/core/sox.py
+++ b/audiofile/core/sox.py
@@ -1,0 +1,14 @@
+import logging
+
+import sox
+
+
+# Disable warning outputs of sox as we use it with try
+logging.getLogger('sox').setLevel(logging.CRITICAL)
+
+
+SOX_ERRORS = (
+    sox.core.SoxError,
+    sox.core.SoxiError,
+    FileNotFoundError,  # sox binary missing
+)

--- a/audiofile/core/utils.py
+++ b/audiofile/core/utils.py
@@ -2,8 +2,6 @@ import os
 import subprocess
 import shlex
 
-import sox
-
 import audeer
 
 
@@ -55,6 +53,7 @@ def run_ffmpeg(infile, outfile, offset, duration):
 
 def run_sox(infile, outfile, offset, duration):
     """Convert audio file to WAV file."""
+    from audiofile.core.sox import sox
     tfm = sox.Transformer()
     if duration:
         tfm.trim(offset, duration + offset)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,10 +4,10 @@ Installation
 :mod:`audiofile` supports WAV, FLAC, OGG out of the box.
 In order to handle all possible audio files,
 please make sure ffmpeg_,
-sox_
-(with MP3 support for best performance),
 and mediainfo_
-are installed on your system,
+are installed on your system.
+For faster access of MP3 files,
+please install sox_ with MP3 bindings as well,
 e.g.
 
 .. code-block:: bash

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,7 +3,7 @@ Installation
 
 :mod:`audiofile` supports WAV, FLAC, OGG out of the box.
 In order to handle all possible audio files,
-please make sure ffmpeg_,
+please make sure ffmpeg_
 and mediainfo_
 are installed on your system.
 For faster access of MP3 files,

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -2,7 +2,7 @@ Installation
 ============
 
 :mod:`audiofile` supports WAV, FLAC, OGG out of the box.
-In order to handle all possible audio files,
+In order to handle other audio formats,
 please make sure ffmpeg_
 and mediainfo_
 are installed on your system.


### PR DESCRIPTION
Closes #62 

This adjusts the code so that `ffmpeg` or `mediainfo` is used if the `sox` binary cannot be found instead of raising an `FileNotFoundError` as before.
It also makes sure that we don't get a warning printed to screen that `sox` is missing.
This is tested by not installing the `sox` binary when building the documentation, which would fail if a warning is given.
In addition, the tests under Python 3.8 are extended to be run with and without `sox` installed:

![image](https://user-images.githubusercontent.com/173624/163171285-807b67a5-d195-48d3-a88f-8721d6fd050e.png)

The installation instructions now mention that `sox` is only optional:

![image](https://user-images.githubusercontent.com/173624/163344532-9fdbcf10-a1d4-48d0-9522-1fc8259ffb73.png)
