### PR TITLE
Custom FileNotFoundError for missing binaries

### DIFF
--- a/audiofile/core/convert.py
+++ b/audiofile/core/convert.py
@@ -35,8 +35,8 @@ def convert(
             # Convert to WAV file with ffmpeg
             run_ffmpeg(infile, outfile, offset, duration)
         except FileNotFoundError:
-            raise RuntimeError(binary_missing_error('ffmpeg'))
+            raise binary_missing_error('ffmpeg')
         except subprocess.CalledProcessError:
-            raise RuntimeError(broken_file_error(infile))
+            raise broken_file_error(infile)
     except OSError:
-        raise RuntimeError(broken_file_error(infile))
+        raise broken_file_error(infile)

--- a/audiofile/core/convert.py
+++ b/audiofile/core/convert.py
@@ -4,6 +4,7 @@ import subprocess
 import audeer
 
 from audiofile.core.utils import (
+    binary_missing_error,
     broken_file_error,
     run_ffmpeg,
     run_sox,
@@ -33,6 +34,8 @@ def convert(
         try:
             # Convert to WAV file with ffmpeg
             run_ffmpeg(infile, outfile, offset, duration)
+        except FileNotFoundError:
+            raise RuntimeError(binary_missing_error('ffmpeg'))
         except subprocess.CalledProcessError:
             raise RuntimeError(broken_file_error(infile))
     except OSError:

--- a/audiofile/core/info.py
+++ b/audiofile/core/info.py
@@ -10,6 +10,7 @@ import audeer
 
 from audiofile.core.convert import convert
 from audiofile.core.utils import (
+    binary_missing_error,
     broken_file_error,
     file_extension,
     run,
@@ -76,7 +77,7 @@ def channels(file: str) -> int:
         number of channels in audio file
 
     Raises:
-        FileNotFoundError: if ffmpeg binary is needed,
+        FileNotFoundError: if mediainfo binary is needed,
             but cannot be found
         RuntimeError: if ``file`` is missing,
             broken or format is not supported
@@ -95,6 +96,8 @@ def channels(file: str) -> int:
             cmd2 = f'mediainfo --Inform="Audio;%Channel(s)%" "{file}"'
             try:
                 return int(run(cmd1))
+            except FileNotFoundError:
+                raise RuntimeError(binary_missing_error('mediainfo'))
             except ValueError:
                 try:
                     return int(run(cmd2))
@@ -135,7 +138,7 @@ def duration(file: str, sloppy=False) -> float:
         duration in seconds of audio file
 
     Raises:
-        FileNotFoundError: if ffmpeg binary is needed,
+        FileNotFoundError: if mediainfo binary is needed,
             but cannot be found
         RuntimeError: if ``file`` is missing,
             broken or format is not supported
@@ -150,11 +153,14 @@ def duration(file: str, sloppy=False) -> float:
             from audiofile.core.sox import sox, SOX_ERRORS
             duration = sox.file_info.duration(file) or 0.0
         except SOX_ERRORS:
-            cmd = f'mediainfo --Inform="Audio;%Duration%" "{file}"'
-            duration = run(cmd)
-            if duration:
-                # Convert to seconds, as mediainfo returns milliseconds
-                duration = float(duration) / 1000
+            try:
+                cmd = f'mediainfo --Inform="Audio;%Duration%" "{file}"'
+                duration = run(cmd)
+                if duration:
+                    # Convert to seconds, as mediainfo returns milliseconds
+                    duration = float(duration) / 1000
+            except FileNotFoundError:
+                raise RuntimeError(binary_missing_error('mediainfo'))
         except OSError:
             raise RuntimeError(broken_file_error(file))
         if duration:
@@ -166,6 +172,10 @@ def duration(file: str, sloppy=False) -> float:
 def samples(file: str) -> int:
     """Number of samples in audio file.
 
+    Audio files that are not WAV, FLAC, or OGG
+    are first converted to WAV,
+    before counting the samples.
+
     Args:
         file: file name of input audio file
 
@@ -173,6 +183,8 @@ def samples(file: str) -> int:
         number of samples in audio file
 
     Raises:
+        FileNotFoundError: if ffmpeg binary is needed,
+            but cannot be found
         RuntimeError: if ``file`` is missing,
             broken or format is not supported
 
@@ -203,7 +215,7 @@ def sampling_rate(file: str) -> int:
         sampling rate of audio file
 
     Raises:
-        FileNotFoundError: if ffmpeg binary is needed,
+        FileNotFoundError: if mediainfo binary is needed,
             but cannot be found
         RuntimeError: if ``file`` is missing,
             broken or format is not supported
@@ -217,11 +229,14 @@ def sampling_rate(file: str) -> int:
             from audiofile.core.sox import sox, SOX_ERRORS
             return int(sox.file_info.sample_rate(file))
         except SOX_ERRORS:
-            cmd = f'mediainfo --Inform="Audio;%SamplingRate%" "{file}"'
-            sampling_rate = run(cmd)
-            if sampling_rate:
-                return int(sampling_rate)
-            else:
-                raise RuntimeError(broken_file_error(file))
+            try:
+                cmd = f'mediainfo --Inform="Audio;%SamplingRate%" "{file}"'
+                sampling_rate = run(cmd)
+                if sampling_rate:
+                    return int(sampling_rate)
+                else:
+                    raise RuntimeError(broken_file_error(file))
+            except FileNotFoundError:
+                raise RuntimeError(binary_missing_error('mediainfo'))
         except OSError:
             raise RuntimeError(broken_file_error(file))

--- a/audiofile/core/info.py
+++ b/audiofile/core/info.py
@@ -76,6 +76,8 @@ def channels(file: str) -> int:
         number of channels in audio file
 
     Raises:
+        FileNotFoundError: if ffmpeg binary is needed,
+            but cannot be found
         RuntimeError: if ``file`` is missing,
             broken or format is not supported
 
@@ -133,6 +135,8 @@ def duration(file: str, sloppy=False) -> float:
         duration in seconds of audio file
 
     Raises:
+        FileNotFoundError: if ffmpeg binary is needed,
+            but cannot be found
         RuntimeError: if ``file`` is missing,
             broken or format is not supported
 
@@ -199,6 +203,8 @@ def sampling_rate(file: str) -> int:
         sampling rate of audio file
 
     Raises:
+        FileNotFoundError: if ffmpeg binary is needed,
+            but cannot be found
         RuntimeError: if ``file`` is missing,
             broken or format is not supported
 

--- a/audiofile/core/info.py
+++ b/audiofile/core/info.py
@@ -97,14 +97,14 @@ def channels(file: str) -> int:
             try:
                 return int(run(cmd1))
             except FileNotFoundError:
-                raise RuntimeError(binary_missing_error('mediainfo'))
+                raise binary_missing_error('mediainfo')
             except ValueError:
                 try:
                     return int(run(cmd2))
                 except ValueError:
-                    raise RuntimeError(broken_file_error(file))
+                    raise broken_file_error(file)
         except OSError:
-            raise RuntimeError(broken_file_error(file))
+            raise broken_file_error(file)
 
 
 def duration(file: str, sloppy=False) -> float:
@@ -138,7 +138,7 @@ def duration(file: str, sloppy=False) -> float:
         duration in seconds of audio file
 
     Raises:
-        FileNotFoundError: if mediainfo binary is needed,
+        FileNotFoundError: if ffmpeg or mediainfo binary is needed,
             but cannot be found
         RuntimeError: if ``file`` is missing,
             broken or format is not supported
@@ -160,9 +160,9 @@ def duration(file: str, sloppy=False) -> float:
                     # Convert to seconds, as mediainfo returns milliseconds
                     duration = float(duration) / 1000
             except FileNotFoundError:
-                raise RuntimeError(binary_missing_error('mediainfo'))
+                raise binary_missing_error('mediainfo')
         except OSError:
-            raise RuntimeError(broken_file_error(file))
+            raise broken_file_error(file)
         if duration:
             return duration
 
@@ -235,8 +235,8 @@ def sampling_rate(file: str) -> int:
                 if sampling_rate:
                     return int(sampling_rate)
                 else:
-                    raise RuntimeError(broken_file_error(file))
+                    raise broken_file_error(file)
             except FileNotFoundError:
-                raise RuntimeError(binary_missing_error('mediainfo'))
+                raise binary_missing_error('mediainfo')
         except OSError:
-            raise RuntimeError(broken_file_error(file))
+            raise broken_file_error(file)

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -40,6 +40,8 @@ def convert_to_wav(
         offset: start reading at offset in seconds
 
     Raises:
+        FileNotFoundError: if ffmpeg binary is needed,
+            but cannot be found
         RuntimeError: if ``file`` is missing,
             broken or format is not supported
 
@@ -97,6 +99,8 @@ def read(
         * sample rate of the audio file
 
     Raises:
+        FileNotFoundError: if ffmpeg binary is needed,
+            but cannot be found
         RuntimeError: if ``file`` is missing,
             broken or format is not supported
 

--- a/audiofile/core/utils.py
+++ b/audiofile/core/utils.py
@@ -5,7 +5,7 @@ import shlex
 import audeer
 
 
-def binary_missing_error(binary: str) -> str:
+def binary_missing_error(binary: str) -> Exception:
     r"""Missing binary error message.
 
     Args:
@@ -15,7 +15,7 @@ def binary_missing_error(binary: str) -> str:
         error message
 
     """
-    return (
+    return FileNotFoundError(
         f'{binary} cannot be found. '
         'Please make sure it is installed. '
         'For further instructions visit: '
@@ -23,7 +23,7 @@ def binary_missing_error(binary: str) -> str:
     )
 
 
-def broken_file_error(file: str) -> str:
+def broken_file_error(file: str) -> Exception:
     r"""Broken file error message.
 
     If we encounter a broken file,
@@ -37,7 +37,7 @@ def broken_file_error(file: str) -> str:
         error message
 
     """
-    return (
+    return RuntimeError(
         f'Error opening {file}: '
         'File contains data in an unknown format.'
     )

--- a/audiofile/core/utils.py
+++ b/audiofile/core/utils.py
@@ -16,8 +16,8 @@ def binary_missing_error(binary: str) -> Exception:
 
     """
     return FileNotFoundError(
-        f'{binary} cannot be found. '
-        'Please make sure it is installed. '
+        f'{binary} cannot be found.\n'
+        'Please make sure it is installed.\n'
         'For further instructions visit: '
         'https://audeering.github.io/audiofile/installation.html'
     )

--- a/audiofile/core/utils.py
+++ b/audiofile/core/utils.py
@@ -5,6 +5,24 @@ import shlex
 import audeer
 
 
+def binary_missing_error(binary: str) -> str:
+    r"""Missing binary error message.
+
+    Args:
+        binary: name of binary
+
+    Returns:
+        error message
+
+    """
+    return (
+        f'{binary} cannot be found. '
+        'Please make sure it is installed. '
+        'For further instructions visit: '
+        'https://audeering.github.io/audiofile/installation.html'
+    )
+
+
 def broken_file_error(file: str) -> str:
     r"""Broken file error message.
 

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -205,19 +205,22 @@ def test_empty_file(tmpdir, convert, empty_file):
 def test_missing_binaries(tmpdir, hide_system_path, empty_file):
     expected_error = FileNotFoundError
     # Reading file
-    with pytest.raises(expected_error):
+    with pytest.raises(expected_error, match='ffmpeg'):
         signal, sampling_rate = af.read(empty_file)
     # Metadata
-    with pytest.raises(expected_error):
-        af.sampling_rate(empty_file)
-    with pytest.raises(expected_error):
-        af.duration(empty_file)
-    with pytest.raises(expected_error):
-        af.duration(empty_file, sloppy=True)
-    with pytest.raises(expected_error):
+    with pytest.raises(expected_error, match='mediainfo'):
         af.channels(empty_file)
+    with pytest.raises(expected_error, match='ffmpeg'):
+        af.duration(empty_file)
+    with pytest.raises(expected_error, match='mediainfo'):
+        af.duration(empty_file, sloppy=True)
+    with pytest.raises(expected_error, match='ffmpeg'):
+        af.samples(empty_file)
+    with pytest.raises(expected_error, match='mediainfo'):
+        af.sampling_rate(empty_file)
+
     # Convert
-    with pytest.raises(expected_error):
+    with pytest.raises(expected_error, match='ffmpeg'):
         converted_file = str(tmpdir.join('signal-converted.wav'))
         af.convert_to_wav(empty_file, converted_file)
 


### PR DESCRIPTION
Closes #30 

When the `ffmpeg` or `mediainfo` binaries are missing we have been raising a `FileNotFoundError` before, but this behavior was not documented and not tested.

This pull request extends the docstrings accordingly, depending on if `ffmpeg` or `mediainfo` is needed:

![image](https://user-images.githubusercontent.com/173624/163187981-9b97a3cb-ba0f-4d0d-abc1-fd40611f3283.png)

In addition, it adds a custom error message to solve #30:

```
E               FileNotFoundError: ffmpeg cannot be found.
E               Please make sure it is installed.
E               For further instructions visit: https://audeering.github.io/audiofile/installation.html
```

And adds tests for the missing binaries.