### PR TITLE
TST: test MP3 file duration in all cases

### DIFF
--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -447,15 +447,12 @@ def test_mp3(tmpdir, magnitude, sampling_rate, channels):
     sig, fs = af.read(mp3_file, offset=offset, duration=duration)
     assert _duration(sig, sampling_rate) == duration
     sig, fs = af.read(mp3_file, offset=offset)
-    # Don't test for 48000 Hz and 2 channels
-    # https://github.com/audeering/audiofile/issues/23
-    if not (sampling_rate == 48000 and channels == 2):
-        assert_allclose(
-            _duration(sig, sampling_rate),
-            af.duration(mp3_file) - offset,
-            rtol=0,
-            atol=tolerance('duration', sampling_rate),
-        )
+    assert_allclose(
+        _duration(sig, sampling_rate),
+        af.duration(mp3_file) - offset,
+        rtol=0,
+        atol=tolerance('duration', sampling_rate),
+    )
 
 
 def test_formats():


### PR DESCRIPTION
Closes #23 

This re-enables the duration test for MP3 files with 2 channels and a sampling rate of 48000 Hz.
I guess the test failed before not due to `audiofile`, but due to the creation of the MP3 files with `sox`, which we changed to `ffmpeg` in https://github.com/audeering/audiofile/pull/72