### PR TITLE
Update license year and authors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,11 @@
 MIT License
 
-Copyright (c) 2018-2020 audEERING GmbH and Contributors
+Copyright (c) 2018-present audEERING GmbH and Contributors
 
-Author: Hagen Wierstorf
+Author:
+    Christian Geng
+    Johannes Wagner
+    Hagen Wierstorf
 
 Contributors: 
     Fabian-Robert Stöter (code for benchmarks)

--- a/LICENSE
+++ b/LICENSE
@@ -3,9 +3,9 @@ MIT License
 Copyright (c) 2018-present audEERING GmbH and Contributors
 
 Author:
-    Christian Geng
-    Johannes Wagner
     Hagen Wierstorf
+    Johannes Wagner
+    Christian Geng
 
 Contributors: 
     Fabian-Robert Stöter (code for benchmarks)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]    
 name = audiofile
-author = Hagen Wierstorf
-author_email = hwierstorf@audeering.com
+author = Hagen Wierstorf, Johannes Wagner, Christian Geng
+author_email = hwierstorf@audeering.com, jwagner@audeering.com, cgeng@audeering.com
 description = Fast reading of all kind of audio files
 long_description = file: README.rst, CHANGELOG.rst
 license = MIT License


### PR DESCRIPTION
Sets second year in LICENSE file to `present` and adds @frankenjoe and @ChristianGeng as authors.