### PR TITLE
TST: require flake8<5.0.0

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,5 @@
+# To avoid https://github.com/tholo/pytest-flake8/issues/87
+flake8 <5.0.0
 pytest
 pytest-cov
 pytest-flake8


### PR DESCRIPTION
To avoid an error with pytest-flake8 (https://github.com/tholo/pytest-flake8/issues/87), this requires `flake<5.0.0`