### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,22 +13,9 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
-        python-version: [ 3.8 ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
         tasks: [ tests ]
         sox: [ sox, no-sox ]  # sox binary present or not
-        include:
-          - os: ubuntu-latest
-            python-version: 3.7
-            tasks: tests
-            sox: sox
-          - os: ubuntu-latest
-            python-version: 3.9
-            tasks: tests
-            sox: sox
-          - os: ubuntu-latest
-            python-version: 3.8
-            tasks: docs
-            sox: no-sox
 
     steps:
     - uses: actions/checkout@v3

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Multimedia :: Sound/Audio
 
 [options]


### PR DESCRIPTION
Add test for Python 3.10, mention Python 3.10 in `setup.cfg` and expand tests for Windows and MacOS to all Python versions.