### PR TITLE
TST: use pre-commit for flake8 checks

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,29 @@
+name: Flake8
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.8'
+
+    - name: Install pre-commit hooks
+      run: |
+        pip install pre-commit
+        pre-commit install --install-hooks
+
+    - name: Code style check via pre-commit
+      run: |
+        pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+# Configuration of checks run by pre-commit
+#
+# The tests are executed in the CI pipeline,
+# see CONTRIBUTING.rst for further instructions.
+# You can also run the checks directly at the terminal, e.g.
+#
+# $ pre-commit install
+# $ pre-commit run --all-files
+#
+repos:
+-   repo: https://github.com/pycqa/flake8
+    rev: '5.0.4'
+    hooks:
+    -   id: flake8

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -7,10 +7,9 @@ If you find errors, omissions, inconsistencies or other things that need
 improvement, please create an issue_.
 Contributions are always welcome!
 
-.. _issue:
-    https://github.com/audeering/audiofile/issues/new
-.. _pull request:
-    https://github.com/audeering/audiofile/compare
+.. _issue: https://github.com/audeering/audiofile/issues/new
+.. _pull request: https://github.com/audeering/audiofile/compare
+
 
 Development Installation
 ------------------------
@@ -35,6 +34,40 @@ If you prefer, you can also replace the last command with::
 
    pip install -r requirements.txt
 
+
+Coding Convention
+-----------------
+
+We follow the PEP8_ convention for Python code
+and check for correct syntax with flake8_.
+Exceptions are defined under the ``[flake8]`` section
+in :file:`setup.cfg`.
+
+The checks are executed in the CI using `pre-commit`_.
+You can enable those checks locally by executing::
+
+    pip install pre-commit  # consider system wide installation
+    pre-commit install
+    pre-commit run --all-files
+
+Afterwards flake8_ is executed
+every time you create a commit.
+
+You can also install flake8_
+and call it directly::
+
+    pip install flake8  # consider system wide installation
+    flake8
+
+It can be restricted to specific folders::
+
+    flake8 audfoo/ tests/
+
+.. _PEP8: http://www.python.org/dev/peps/pep-0008/
+.. _flake8: https://flake8.pycqa.org/en/latest/index.html
+.. _pre-commit: https://pre-commit.com
+
+
 Building the Documentation
 --------------------------
 
@@ -56,6 +89,7 @@ It is also possible to automatically check if all links are still valid::
 
 .. _Sphinx: http://sphinx-doc.org/
 
+
 Running the Tests
 -----------------
 
@@ -69,6 +103,7 @@ To execute the tests, simply run::
    python -m pytest
 
 .. _pytest: https://pytest.org/
+
 
 Creating a New Release
 ----------------------

--- a/docs/benchmark/benchmark_info.py
+++ b/docs/benchmark/benchmark_info.py
@@ -1,4 +1,3 @@
-import contextlib
 import os
 import os.path
 import time

--- a/docs/benchmark/benchmark_read.py
+++ b/docs/benchmark/benchmark_read.py
@@ -1,6 +1,5 @@
 import argparse
 import os
-import random
 import time
 
 import matplotlib

--- a/docs/benchmark/loaders.py
+++ b/docs/benchmark/loaders.py
@@ -3,7 +3,6 @@ import audioread.rawread
 import audioread.gstdec
 import audioread.maddec
 import audioread.ffdec
-import matplotlib.pyplot as plt
 import soundfile as sf
 import audiofile as af
 import aubio

--- a/docs/benchmark/plot.py
+++ b/docs/benchmark/plot.py
@@ -1,5 +1,3 @@
-import sys
-
 import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt

--- a/docs/benchmark/utils.py
+++ b/docs/benchmark/utils.py
@@ -1,5 +1,3 @@
-import numpy as np
-import subprocess as sp
 import os
 import pandas as pd
 import seaborn as sns

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ setup_requires =
 
 [tool:pytest]
 addopts =
-    --flake8
     --cov=audiofile
     --cov-report term-missing
     --cov-report xml
@@ -47,6 +46,12 @@ addopts =
 xfail_strict = true
 
 [flake8]
-ignore =
-    W503  # math, https://github.com/PyCQA/pycodestyle/issues/513
-     __init__.py F401  # ignore unused imports
+exclude =
+    .eggs,
+    build,
+extend-ignore =
+    # math, https://github.com/PyCQA/pycodestyle/issues/513
+    W503,
+per-file-ignores =
+    # ignore unused imports
+    __init__.py: F401,

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,3 @@
-# To avoid https://github.com/tholo/pytest-flake8/issues/87
-flake8 <5.0.0
 pytest
 pytest-cov
-pytest-flake8
 sox

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -1,7 +1,6 @@
 from __future__ import division
 import os
 import subprocess
-import tempfile
 
 import pytest
 import numpy as np


### PR DESCRIPTION
This uses [pre-commit](https://pre-commit.com) instead of `pytest` to execute the `flake8` tests.

It also fixes a few flake8 issues and adds a coding convention section to CONTRIBUTING.