### PR TITLE
Ensure convert_to_wav() creates desired WAV file

### DIFF
--- a/audiofile/core/info.py
+++ b/audiofile/core/info.py
@@ -8,7 +8,7 @@ import soundfile
 
 import audeer
 
-from audiofile.core.convert import convert
+from audiofile.core.io import convert_to_wav
 from audiofile.core.utils import (
     binary_missing_error,
     broken_file_error,
@@ -204,7 +204,7 @@ def samples(file: str) -> int:
         # Always convert to WAV for non SNDFORMATS
         with tempfile.TemporaryDirectory(prefix='audiofile') as tmpdir:
             tmpfile = os.path.join(tmpdir, 'tmp.wav')
-            convert(file, tmpfile)
+            convert_to_wav(file, tmpfile)
             return samples_as_int(tmpfile)
 
 

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -60,8 +60,8 @@ def convert_to_wav(
         duration=duration,
     )
     write(outfile, signal, sampling_rate, bit_depth=bit_depth, **kwargs)
-    
-    
+
+
 def read(
         file: str,
         duration: float = None,

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -8,7 +8,6 @@ import soundfile
 import audeer
 
 from audiofile.core.convert import convert
-import audiofile.core.info as info
 from audiofile.core.utils import (
     file_extension,
     MAX_CHANNELS,
@@ -21,20 +20,30 @@ def convert_to_wav(
         outfile: str,
         offset: float = 0,
         duration: float = None,
+        bit_depth: int = 16,
+        normalize: bool = False,
+        **kwargs,
 ):
     """Convert any audio/video file to WAV.
 
-    It uses soundfile for converting WAV, FLAC, OGG files,
-    and sox or ffmpeg for converting all other files.
+    It uses soundfile for reading WAV, FLAC, OGG files,
+    and sox or ffmpeg for reading all other files.
     If ``duration`` and/or ``offset`` are specified
     the resulting WAV file
     will be shortened accordingly.
+
+    It then uses :func:`soundfile.write` to write the WAV file,
+    which limits the number of supported channels to 65535.
 
     Args:
         infile: audio/video file name
         outfile: WAV file name
         duration: return only a specified duration in seconds
         offset: start reading at offset in seconds
+        bit_depth: bit depth of written file in bit,
+            can be 8, 16, 24
+        normalize: normalize audio data before writing
+        kwargs: pass on further arguments to :func:`soundfile.write`
 
     Raises:
         FileNotFoundError: if ffmpeg binary is needed,
@@ -45,20 +54,14 @@ def convert_to_wav(
     """
     infile = audeer.safe_path(infile)
     outfile = audeer.safe_path(outfile)
-    if file_extension(infile) in SNDFORMATS:
-        bit_depth = info.bit_depth(infile)
-        if bit_depth is None:
-            bit_depth = 16
-        signal, sampling_rate = read(
-            infile,
-            offset=offset,
-            duration=duration,
-        )
-        write(outfile, signal, sampling_rate, bit_depth=bit_depth)
-    else:
-        convert(infile, outfile, offset, duration)
-
-
+    signal, sampling_rate = read(
+        infile,
+        offset=offset,
+        duration=duration,
+    )
+    write(outfile, signal, sampling_rate, bit_depth=bit_depth, **kwargs)
+    
+    
 def read(
         file: str,
         duration: float = None,
@@ -126,7 +129,9 @@ def read(
             )
     else:
         if duration is not None or offset > 0:
-            sampling_rate = info.sampling_rate(file)
+            # We don't use audiofile.sampling_rate(file) here
+            # to avoid circular imports
+            sampling_rate = soundfile.info(file).samplerate
         if offset > 0:
             offset = np.ceil(offset * sampling_rate)  # samples
         if duration is not None:

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -305,15 +305,15 @@ def test_convert_to_wav(tmpdir, bit_depth, file_extension):
     else:
         af.write(infile, signal, sampling_rate, bit_depth=bit_depth)
     outfile = str(tmpdir.join('signal_converted.wav'))
-    af.convert_to_wav(infile, outfile)
+    af.convert_to_wav(infile, outfile, bit_depth=bit_depth)
     converted_signal, converted_sampling_rate = af.read(outfile)
     assert converted_sampling_rate == sampling_rate
     if file_extension == 'mp3':
-        assert af.bit_depth(outfile) == 16
+        assert af.bit_depth(outfile) == bit_depth
         # Don't compare signals for MP3
         # as duration differs as well
     elif file_extension == 'ogg':
-        assert af.bit_depth(outfile) == 16
+        assert af.bit_depth(outfile) == bit_depth
         assert np.abs(converted_signal - signal).max() < 0.06
     elif file_extension in ['wav', 'flac']:
         assert af.bit_depth(outfile) == bit_depth


### PR DESCRIPTION
The goal of this pull request is that the following two commands will always result in the same outfile.

```python
audiofile.convert_to_wav(infile, outfile)
```

```python
signal, sampling_rate = audiofile.read(infile)
audiofile.write(outfile, signal, sampling_rate)
```

---

This was not the case before. E.g. executing `audiofile.convert_to_wav()` on a SPH file from LDC could lead to the following WAV file (compare https://github.com/audeering/audb/issues/161):

```bash
$ soxi sw_10001.wav


Input File     : 'sw_10001.wav'
Channels       : 2
Sample Rate    : 8000
Precision      : 14-bit
Duration       : 00:05:00.00 = 2400000 samples ~ 22500 CDDA sectors
File Size      : 4.80M
Bit Rate       : 128k
Sample Encoding: 8-bit u-law
```

whereas a conversion by using `audiofile.read()` and `audiofile.write()` will lead to the desired WAV file (having Signed Integer PCM):

```bash
$ soxi sw_10001.wav

Input File     : 'sw_10001.wav'
Channels       : 2
Sample Rate    : 8000
Precision      : 16-bit
Duration       : 00:05:00.00 = 2400000 samples ~ 22500 CDDA sectors
File Size      : 9.60M
Bit Rate       : 256k
Sample Encoding: 16-bit Signed Integer PCM
```

---

To achieve this I had to add the `bit_depth` argument to `convert_to_wav()` and set it to the same default value of `16` as for `audiofile.write()`. In addition, I also added `normalize` and `**kwargs` which are passed on to `audiofile.write()`.

![image](https://user-images.githubusercontent.com/173624/214523662-3f96bcfa-e17b-448e-b6ca-aed3224299bc.png)

/cc @Bahaabrougui @ureichel 