### PR TITLE
CI: use micromamba instead of conda for sox

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,15 +31,14 @@ jobs:
       with:
         cache-env: true
         environment-file: false
-        environment-name: venv-sox
+        environment-name: venv
         extra-specs: |
           pip
           python=${{ matrix.python-version }}
-          sox
         channels: conda-forge
 
     - name: Activate Python virtual environment
-      run: micromamba activate venv-sox
+      run: micromamba activate venv
 
     - name: Install sox with Micromamba
       run: micromamba install sox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,9 @@ jobs:
       if: matrix.os == 'windows-latest'
 
     - name: Activate micromamba env
-      run: micromamba activate venv-sox
+      run: |
+        micromamba shell init --shell=bash --prefix=~/micromamba
+        micromamba activate venv-sox
       if: matrix.sox == 'sox'
 
     - name: Install package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,19 +25,16 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Set up conda
-      uses: s-weigand/setup-conda@v1
+    - name: Install Conda environment with Micromamba
+      uses: mamba-org/provision-with-micromamba@main
       with:
-        activate-conda: false  # don't switch Python version
-      if: matrix.sox == 'sox'
-
-    - name: Install sox using conda
-      # MP3 support under Linux and macOS, see
-      # https://github.com/conda-forge/sox-feedstock/pull/18
-      run: |
-        conda config --add channels conda-forge
-        conda config --set channel_priority strict
-        conda install sox
+        cache-env: true
+        environment-file: false
+        environment-name: venv-sox
+        extra-specs: |
+          python=${{ matrix.python-version }}
+          sox
+        channels: conda-forge
       if: matrix.sox == 'sox'
 
     - name: Ubuntu - install libsndfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,8 @@ jobs:
       if: matrix.tasks == 'tests'
 
     - name: Show sox version
-      run: sox --version
+      run: |
+        if $(which sox >/dev/null); then sox --version; else echo "No sox installed"; fi
 
     - name: Test with pytest
       run: python -m pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,7 @@ jobs:
       run: |
         eval "$(micromamba shell hook --shell=bash)"
         micromamba activate venv-sox
+        sox --version
       if: matrix.sox == 'sox'
 
     - name: Install package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
 
     - name: Activate micromamba env
       run: |
-        micromamba shell init --shell=bash --prefix=~/micromamba
+        eval "$(micromamba shell hook --shell=bash)"
         micromamba activate venv-sox
       if: matrix.sox == 'sox'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,24 +20,21 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    # - name: Set up Python ${{ matrix.python-version }}
-    #  - uses: actions/setup-python@v4
-    #  - with:
-    #  -   python-version: ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
 
-    - name: Set up Python ${{ matrix.python-version }} with Micromamba
+    - name: Install Conda environment with Micromamba
       uses: mamba-org/provision-with-micromamba@main
       with:
         cache-env: true
         environment-file: false
-        environment-name: venv
+        environment-name: venv-sox
         extra-specs: |
-          pip
           python=${{ matrix.python-version }}
+          sox
         channels: conda-forge
-
-    - name: Install sox
-      run: micromamba install sox
       if: matrix.sox == 'sox'
 
     - name: Ubuntu - install libsndfile
@@ -62,6 +59,7 @@ jobs:
 
     - name: Install package
       run: |
+        python -m pip install --upgrade pip
         pip install -r requirements.txt
 
     # TESTS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,12 @@ on:
 jobs:
   build:
 
+    # Make sure .bashrc is read by shell for micromamba,
+    # see https://github.com/mamba-org/provision-with-micromamba#important
+    defaults:
+      run:
+        shell: bash -l {0}
+
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
-      if: matrix.sox == 'sox'
 
     runs-on: ${{ matrix.os }}
     strategy:
@@ -26,12 +25,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-      if: matrix.sox == 'no-sox'
 
     - name: Set up Python ${{ matrix.python-version }} with Micromamba
       uses: mamba-org/provision-with-micromamba@main
@@ -45,6 +38,9 @@ jobs:
           sox
         channels: conda-forge
       run: micromamba activate venv-sox
+
+    - name: Install sox with Micromamba
+      run: micromamba install sox
       if: matrix.sox == 'sox'
 
     - name: Ubuntu - install libsndfile
@@ -69,7 +65,6 @@ jobs:
 
     - name: Install package
       run: |
-        # python -m pip install --upgrade pip
         pip install -r requirements.txt
 
     # TESTS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,6 @@ jobs:
 
     - name: Show sox version
       run: sox --version
-      if: matrix.sox == 'sox'
 
     - name: Test with pytest
       run: python -m pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,14 +24,16 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+      if: matrix.sox == 'no-sox'
 
-    - name: Install Conda environment with Micromamba
+    - name: Set up Python ${{ matrix.python-version }} with Micromamba
       uses: mamba-org/provision-with-micromamba@main
       with:
         cache-env: true
         environment-file: false
         environment-name: venv-sox
         extra-specs: |
+          pip
           python=${{ matrix.python-version }}
           sox
         channels: conda-forge
@@ -57,9 +59,13 @@ jobs:
       run: choco install ffmpeg mediainfo-cli
       if: matrix.os == 'windows-latest'
 
+    - name: Activate micromamba env
+      run: micromamba activate venv-sox
+      if: matrix.sox == 'sox'
+
     - name: Install package
       run: |
-        python -m pip install --upgrade pip
+        # python -m pip install --upgrade pip
         pip install -r requirements.txt
 
     # TESTS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,10 @@ jobs:
       run: pip install -r tests/requirements.txt
       if: matrix.tasks == 'tests'
 
+    - name: Show sox version
+      run: sox --version
+      if: matrix.sox == 'sox'
+
     - name: Test with pytest
       run: python -m pytest
       if: matrix.tasks == 'tests'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
+      if: matrix.sox == 'sox'
 
     runs-on: ${{ matrix.os }}
     strategy:
@@ -43,6 +44,7 @@ jobs:
           python=${{ matrix.python-version }}
           sox
         channels: conda-forge
+      run: micromamba activate venv-sox
       if: matrix.sox == 'sox'
 
     - name: Ubuntu - install libsndfile
@@ -64,13 +66,6 @@ jobs:
     - name: Windows - install ffmpeg/mediainfo
       run: choco install ffmpeg mediainfo-cli
       if: matrix.os == 'windows-latest'
-
-    - name: Activate micromamba env
-      run: |
-        eval "$(micromamba shell hook --shell=bash)"
-        micromamba activate venv-sox
-        sox --version
-      if: matrix.sox == 'sox'
 
     - name: Install package
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,8 @@ jobs:
           python=${{ matrix.python-version }}
           sox
         channels: conda-forge
+
+    - name: Activate Python virtual environment
       run: micromamba activate venv-sox
 
     - name: Install sox with Micromamba

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,21 +20,24 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
+    # - name: Set up Python ${{ matrix.python-version }}
+    #  - uses: actions/setup-python@v4
+    #  - with:
+    #  -   python-version: ${{ matrix.python-version }}
 
-    - name: Install Conda environment with Micromamba
+    - name: Set up Python ${{ matrix.python-version }} with Micromamba
       uses: mamba-org/provision-with-micromamba@main
       with:
         cache-env: true
         environment-file: false
-        environment-name: venv-sox
+        environment-name: venv
         extra-specs: |
+          pip
           python=${{ matrix.python-version }}
-          sox
         channels: conda-forge
+
+    - name: Install sox
+      run: micromamba install sox
       if: matrix.sox == 'sox'
 
     - name: Ubuntu - install libsndfile
@@ -59,7 +62,6 @@ jobs:
 
     - name: Install package
       run: |
-        python -m pip install --upgrade pip
         pip install -r requirements.txt
 
     # TESTS


### PR DESCRIPTION
This uses `micromamba` which is a faster alternative for `conda` from https://github.com/mamba-org/mamba.
It can still install all the `conda` packages and use the `conda` repos like `conda-forge`.

The main motivation for this switch are:

* we got an error with `conda` for whatever reason at https://github.com/audeering/audiofile/actions/runs/4004437981/jobs/6873558679
* the time for setting up `sox` with `conda` is 150 s, with `micromamba` it is 40 s in the first run and 8 s when running a second time in the same branch due to caching

I now use `micromamba` also to handle the case where we don't need to install `sox` to create a virtual environment with the desired Python version replacing `actions/setup-python@v4` as it is not slower and makes the code easier to write and to understand.