### PR TITLE
DOC: add docstring examples

### DIFF
--- a/audiofile/core/conftest.py
+++ b/audiofile/core/conftest.py
@@ -1,0 +1,30 @@
+import os
+
+import numpy as np
+import pytest
+
+import audeer
+import audiofile
+
+
+np.random.seed(1)
+
+
+@pytest.fixture(scope='session', autouse=True)
+def audio_file():
+    # Create an audio file to be used in doctests
+    sampling_rate = 8000
+    signal = np.random.uniform(-1, 1, (1, 1000))
+    mono_file = audeer.path('mono.wav')
+    audiofile.write('mono.wav', signal, sampling_rate)
+    signal = np.random.uniform(-1, 1, (2, 1000))
+    stereo_file = audeer.path('stereo.wav')
+    audiofile.write(stereo_file, signal, sampling_rate)
+
+    yield
+
+    # Clean up
+    if os.path.exists(mono_file):
+        os.remove(mono_file)
+    if os.path.exists(stereo_file):
+        os.remove(stereo_file)

--- a/audiofile/core/conftest.py
+++ b/audiofile/core/conftest.py
@@ -14,17 +14,22 @@ np.random.seed(1)
 def audio_file():
     # Create an audio file to be used in doctests
     sampling_rate = 8000
+    mono_wav_file = audeer.path('mono.wav')
+    stereo_wav_file = audeer.path('stereo.wav')
+    stereo_flac_file = audeer.path('stereo.flac')
     signal = np.random.uniform(-1, 1, (1, 1000))
-    mono_file = audeer.path('mono.wav')
-    audiofile.write('mono.wav', signal, sampling_rate)
+    audiofile.write(mono_wav_file, signal, sampling_rate)
     signal = np.random.uniform(-1, 1, (2, 1000))
-    stereo_file = audeer.path('stereo.wav')
-    audiofile.write(stereo_file, signal, sampling_rate)
+    audiofile.write(stereo_wav_file, signal, sampling_rate)
+    audiofile.write(stereo_flac_file, signal, sampling_rate)
 
     yield
 
     # Clean up
-    if os.path.exists(mono_file):
-        os.remove(mono_file)
-    if os.path.exists(stereo_file):
-        os.remove(stereo_file)
+    for file in [
+            mono_wav_file,
+            stereo_wav_file,
+            stereo_flac_file,
+    ]:
+        if os.path.exists(file):
+            os.remove(file)

--- a/audiofile/core/info.py
+++ b/audiofile/core/info.py
@@ -34,6 +34,10 @@ def bit_depth(file: str) -> typing.Optional[int]:
         RuntimeError: if ``file`` is missing,
             broken or format is not supported
 
+    Examples:
+        >>> bit_depth('stereo.wav')
+        16
+
     """
     file = audeer.safe_path(file)
     file_type = file_extension(file)
@@ -81,6 +85,10 @@ def channels(file: str) -> int:
             but cannot be found
         RuntimeError: if ``file`` is missing,
             broken or format is not supported
+
+    Examples:
+        >>> channels('stereo.wav')
+        2
 
     """
     file = audeer.safe_path(file)
@@ -141,6 +149,10 @@ def duration(file: str, sloppy=False) -> float:
         RuntimeError: if ``file`` is missing,
             broken or format is not supported
 
+    Examples:
+        >>> duration('stereo.wav')
+        0.125
+
     """
     file = audeer.safe_path(file)
     if file_extension(file) in SNDFORMATS:
@@ -191,6 +203,10 @@ def samples(file: str) -> int:
         RuntimeError: if ``file`` is missing,
             broken or format is not supported
 
+    Examples:
+        >>> samples('stereo.wav')
+        1000
+
     """
     def samples_as_int(file):
         return int(
@@ -222,6 +238,10 @@ def sampling_rate(file: str) -> int:
             but cannot be found
         RuntimeError: if ``file`` is missing,
             broken or format is not supported
+
+    Examples:
+        >>> sampling_rate('stereo.wav')
+        8000
 
     """
     file = audeer.safe_path(file)

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -51,6 +51,9 @@ def convert_to_wav(
         RuntimeError: if ``file`` is missing,
             broken or format is not supported
 
+    Examples:
+        >>> convert_to_wav('stereo.flac', 'stereo.wav')
+
     """
     infile = audeer.safe_path(infile)
     outfile = audeer.safe_path(outfile)
@@ -197,7 +200,14 @@ def write(
     Raises:
         RuntimeError: for non-supported bit depth or number of channels
 
-    """
+    Examples:
+        >>> sampling_rate = 8000
+        >>> signal = np.random.uniform(-1, 1, (1, 1000))
+        >>> write('mono.wav', signal, sampling_rate)
+        >>> signal = np.random.uniform(-1.2, 1.2, (2, 1000))
+        >>> write('stereo.flac', signal, sampling_rate, normalize=True)
+
+    """  # noqa: E501
     file = audeer.safe_path(file)
     file_type = file_extension(file)
 

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -104,6 +104,19 @@ def read(
         RuntimeError: if ``file`` is missing,
             broken or format is not supported
 
+    Examples:
+        >>> signal, sampling_rate = read('mono.wav')
+        >>> sampling_rate
+        8000
+        >>> signal.shape
+        (1000,)
+        >>> signal, sampling_rate = read('mono.wav', always_2d=True)
+        >>> signal.shape
+        (1, 1000)
+        >>> signal, sampling_rate = read('stereo.wav', duration=0.1)
+        >>> signal.shape
+        (2, 800)
+
     """
     file = audeer.safe_path(file)
     tmpdir = None

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,10 +39,12 @@ setup_requires =
 
 [tool:pytest]
 addopts =
+    --doctest-plus
     --cov=audiofile
     --cov-report term-missing
     --cov-report xml
     --cov-fail-under=100
+    --ignore=docs
 xfail_strict = true
 
 [flake8]

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-cov
+pytest-doctestplus
 sox


### PR DESCRIPTION
Closes #95

This adds examples to all docstrings.

It adds a `conftest.py` file to `audiofile/core/` to create `mono.wav`, `stereo.wav`, and `stereo.flac` files before the doctests are executed and remove them afterwards.

## read()

![image](https://user-images.githubusercontent.com/173624/215029597-0067eb8c-c210-4860-b9ee-dda6ac5a6199.png)

## write()

![image](https://user-images.githubusercontent.com/173624/215029634-e62e30ae-b83a-4e1e-ad00-46eecc7841dc.png)

## bit_depth()

![image](https://user-images.githubusercontent.com/173624/215029678-a5074ce6-47f7-4563-94ce-117c5bbfc649.png)

## channels()

![image](https://user-images.githubusercontent.com/173624/215029713-3dbeac6f-78f6-410e-af56-9b3e8b4bf53c.png)

## duration()

![image](https://user-images.githubusercontent.com/173624/215029748-6ebc3175-44c1-4b5f-9467-2085aafbf3d4.png)

## samples()

![image](https://user-images.githubusercontent.com/173624/215029810-9eff5e08-b647-4c39-884b-f39904b61417.png)

## sampling_rate()

![image](https://user-images.githubusercontent.com/173624/215029867-286cf235-4408-4447-8537-0fb40fc0ca7a.png)

## convert_to_wav()

![image](https://user-images.githubusercontent.com/173624/215029902-c9a6b639-c3d0-42dd-84ed-4ed4f7676328.png)
