### PR TITLE
Return WAV path in convert_to_path()

### DIFF
--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -52,7 +52,9 @@ def convert_to_wav(
             broken or format is not supported
 
     Examples:
-        >>> convert_to_wav('stereo.flac', 'stereo.wav')
+        >>> path = convert_to_wav('stereo.flac', 'stereo.wav')
+        >>> os.path.basename(path)
+        'stereo.wav'
 
     """
     infile = audeer.safe_path(infile)
@@ -63,6 +65,7 @@ def convert_to_wav(
         duration=duration,
     )
     write(outfile, signal, sampling_rate, bit_depth=bit_depth, **kwargs)
+    return outfile
 
 
 def read(

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -23,7 +23,7 @@ def convert_to_wav(
         bit_depth: int = 16,
         normalize: bool = False,
         **kwargs,
-):
+) -> str:
     """Convert any audio/video file to WAV.
 
     It uses soundfile for reading WAV, FLAC, OGG files,

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -45,6 +45,9 @@ def convert_to_wav(
         normalize: normalize audio data before writing
         kwargs: pass on further arguments to :func:`soundfile.write`
 
+    Returns:
+        absolute path to resulting WAV file
+
     Raises:
         FileNotFoundError: if ffmpeg binary is needed,
             but cannot be found

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -179,7 +179,8 @@ def test_read(tmpdir, duration, offset):
 def test_empty_file(tmpdir, convert, empty_file):
     if convert:
         converted_file = str(tmpdir.join('signal-converted.wav'))
-        af.convert_to_wav(empty_file, converted_file)
+        path = af.convert_to_wav(empty_file, converted_file)
+        assert path == audeer.path(converted_file)
         empty_file = converted_file
     # Reading file
     signal, sampling_rate = af.read(empty_file)


### PR DESCRIPTION
Closes https://github.com/audeering/audiofile/issues/102

This let `audiofile.convert_to_wav(infile, outfile)` return the absolute path to `outfile`.

![image](https://user-images.githubusercontent.com/173624/215068180-2449c9be-0575-47d3-a36b-888989cfa4ca.png)
