### PR TITLE
Allow outfile=None in convert_to_wav()

### DIFF
--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -46,8 +46,8 @@ def convert_to_wav(
         bit_depth: bit depth of written file in bit,
             can be 8, 16, 24
         normalize: normalize audio data before writing
-        overwrite: force overwriting of WAV ``infile``
-            if no ``outfile`` is provided
+        overwrite: force overwriting
+            if ``outfile`` is identical to ``outfile``
         kwargs: pass on further arguments to :func:`soundfile.write`
 
     Returns:

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -22,6 +22,7 @@ def convert_to_wav(
         duration: float = None,
         bit_depth: int = 16,
         normalize: bool = False,
+        overwrite: bool = False,
         **kwargs,
 ) -> str:
     """Convert any audio/video file to WAV.
@@ -45,6 +46,8 @@ def convert_to_wav(
         bit_depth: bit depth of written file in bit,
             can be 8, 16, 24
         normalize: normalize audio data before writing
+        overwrite: force overwriting of WAV ``infile``
+            if no ``outfile`` is provided
         kwargs: pass on further arguments to :func:`soundfile.write`
 
     Returns:
@@ -55,6 +58,8 @@ def convert_to_wav(
             but cannot be found
         RuntimeError: if ``file`` is missing,
             broken or format is not supported
+        RuntimeError: if ``infile`` would need to be overwritten
+            and ``overwrite`` is ``False``
 
     Examples:
         >>> path = convert_to_wav('stereo.flac')
@@ -67,8 +72,15 @@ def convert_to_wav(
         outfile = audeer.replace_file_extension(infile, 'wav')
     else:
         outfile = audeer.safe_path(outfile)
-    if infile == outfile:
-        return outfile
+    if (
+            infile == outfile
+            and not overwrite
+    ):
+        raise RuntimeError(
+            f"'{infile}' would need to be overwritten. "
+            "Select 'overwrite=True', "
+            "or provide an 'outfile' argument."
+        )
     signal, sampling_rate = read(
         infile,
         offset=offset,

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -17,7 +17,7 @@ from audiofile.core.utils import (
 
 def convert_to_wav(
         infile: str,
-        outfile: str,
+        outfile: str = None,
         offset: float = 0,
         duration: float = None,
         bit_depth: int = 16,
@@ -37,7 +37,9 @@ def convert_to_wav(
 
     Args:
         infile: audio/video file name
-        outfile: WAV file name
+        outfile: WAV file name.
+            If ``None`` same path as ``infile``
+            but file extension is replaced by ``'wav'``
         duration: return only a specified duration in seconds
         offset: start reading at offset in seconds
         bit_depth: bit depth of written file in bit,
@@ -55,13 +57,16 @@ def convert_to_wav(
             broken or format is not supported
 
     Examples:
-        >>> path = convert_to_wav('stereo.flac', 'stereo.wav')
+        >>> path = convert_to_wav('stereo.flac')
         >>> os.path.basename(path)
         'stereo.wav'
 
     """
     infile = audeer.safe_path(infile)
-    outfile = audeer.safe_path(outfile)
+    if outfile is None:
+        outfile = audeer.replace_file_extension(infile, 'wav')
+    else:
+        outfile = audeer.safe_path(outfile)
     signal, sampling_rate = read(
         infile,
         offset=offset,

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -67,6 +67,8 @@ def convert_to_wav(
         outfile = audeer.replace_file_extension(infile, 'wav')
     else:
         outfile = audeer.safe_path(outfile)
+    if infile == outfile:
+        return outfile
     signal, sampling_rate = read(
         infile,
         offset=offset,

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -77,7 +77,7 @@ def convert_to_wav(
             and not overwrite
     ):
         raise RuntimeError(
-            f"'{infile}' would need to be overwritten. "
+            f"'{infile}' would be overwritten. "
             "Select 'overwrite=True', "
             "or provide an 'outfile' argument."
         )

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -308,7 +308,7 @@ def test_convert_to_wav(tmpdir, bit_depth, file_extension):
         af.write(infile, signal, sampling_rate, bit_depth=bit_depth)
     if file_extension == 'wav':
         error_msg = (
-            f"'{infile}' would need to be overwritten. "
+            f"'{infile}' would be overwritten. "
             "Select 'overwrite=True', "
             "or provide an 'outfile' argument."
         )

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -1,5 +1,6 @@
 from __future__ import division
 import os
+import re
 import subprocess
 
 import pytest
@@ -311,7 +312,7 @@ def test_convert_to_wav(tmpdir, bit_depth, file_extension):
             "Select 'overwrite=True', "
             "or provide an 'outfile' argument."
         )
-        with pytest.raises(RuntimeError, match=error_msg):
+        with pytest.raises(RuntimeError, match=re.escape(error_msg)):
             outfile = af.convert_to_wav(infile, bit_depth=bit_depth)
         outfile = af.convert_to_wav(
             infile,

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -305,7 +305,20 @@ def test_convert_to_wav(tmpdir, bit_depth, file_extension):
         convert_to_mp3(tmpfile, infile, sampling_rate, channels)
     else:
         af.write(infile, signal, sampling_rate, bit_depth=bit_depth)
-    if file_extension in ['wav', 'mp3']:
+    if file_extension == 'wav':
+        error_msg = (
+            f"'{infile}' would need to be overwritten. "
+            "Select 'overwrite=True', "
+            "or provide an 'outfile' argument."
+        )
+        with pytest.raises(RuntimeError, match=error_msg):
+            outfile = af.convert_to_wav(infile, bit_depth=bit_depth)
+        outfile = af.convert_to_wav(
+            infile,
+            bit_depth=bit_depth,
+            overwrite=True,
+        )
+    elif file_extension == 'mp3':
         outfile = af.convert_to_wav(infile, bit_depth=bit_depth)
     else:
         outfile = str(tmpdir.join('signal_converted.wav'))

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -305,7 +305,7 @@ def test_convert_to_wav(tmpdir, bit_depth, file_extension):
         convert_to_mp3(tmpfile, infile, sampling_rate, channels)
     else:
         af.write(infile, signal, sampling_rate, bit_depth=bit_depth)
-    if file_extension == 'mp3':
+    if file_extension in ['wav', 'mp3']:
         outfile = af.convert_to_wav(infile, bit_depth=bit_depth)
     else:
         outfile = str(tmpdir.join('signal_converted.wav'))

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -305,8 +305,11 @@ def test_convert_to_wav(tmpdir, bit_depth, file_extension):
         convert_to_mp3(tmpfile, infile, sampling_rate, channels)
     else:
         af.write(infile, signal, sampling_rate, bit_depth=bit_depth)
-    outfile = str(tmpdir.join('signal_converted.wav'))
-    af.convert_to_wav(infile, outfile, bit_depth=bit_depth)
+    if file_extension == 'mp3':
+        outfile = af.convert_to_wav(infile, bit_depth=bit_depth)
+    else:
+        outfile = str(tmpdir.join('signal_converted.wav'))
+        af.convert_to_wav(infile, outfile, bit_depth=bit_depth)
     converted_signal, converted_sampling_rate = af.read(outfile)
     assert converted_sampling_rate == sampling_rate
     if file_extension == 'mp3':


### PR DESCRIPTION
Closes #103 

This extends `audiofile.convert_to_wav()` by changing the `outfile` argument to `outfile=None` which then uses the same path as `infile`, but replaces the file extension with WAV.
It also adds the `overwrite` argument, to handle cases where the name of the resulting `outfile` is identical to the `infile`.

![image](https://user-images.githubusercontent.com/173624/215451055-c0895150-2d9f-4bb4-b2b7-2de187ce8fc8.png)
