### PR TITLE
Fix: support for non SND files on Windows network shares

### DIFF
--- a/audiofile/core/utils.py
+++ b/audiofile/core/utils.py
@@ -63,12 +63,12 @@ def run_ffmpeg(infile, outfile, offset, duration):
     """Convert audio file to WAV file."""
     if duration:
         cmd = [
-                  'ffmpeg',
-                  '-ss', str(offset),
-                  '-i', infile,
-                  '-t', str(duration),
-                  outfile
-              ]
+            'ffmpeg',
+            '-ss', str(offset),
+            '-i', infile,
+            '-t', str(duration),
+            outfile
+        ]
     else:
         cmd = [
             'ffmpeg',

--- a/audiofile/core/utils.py
+++ b/audiofile/core/utils.py
@@ -50,7 +50,7 @@ def file_extension(path):
 def run(shell_command):
     """Return the output of a shell command provided as string."""
     out = subprocess.check_output(
-        shlex.split(shell_command),
+        shell_command,
         stderr=subprocess.STDOUT
     )
     try:
@@ -62,18 +62,18 @@ def run(shell_command):
 def run_ffmpeg(infile, outfile, offset, duration):
     """Convert audio file to WAV file."""
     if duration:
-        cmd = f'ffmpeg -ss {offset} -i "{infile}" -t {duration} "{outfile}"'
+        cmd = ['ffmpeg', '-ss', str(offset), '-i', infile, '-t', str(duration), outfile]
     else:
-        cmd = f'ffmpeg -ss {offset} -i "{infile}" "{outfile}"'
+        cmd = ['ffmpeg', '-ss', str(offset), '-i', infile, outfile]
     run(cmd)
 
 
 def run_sox(infile, outfile, offset, duration):
     """Convert audio file to WAV file."""
     if duration:
-        cmd = f'sox "{infile}" "{outfile}" trim {offset} {duration}'
+        cmd = ['sox' infile, outfile, 'trim' str(offset) str(duration)]
     else:
-        cmd = f'sox "{infile}" "{outfile}" trim {offset}'
+        cmd = ['sox' infile, outfile, 'trim' str(offset)]
     run(cmd)
 
 

--- a/audiofile/core/utils.py
+++ b/audiofile/core/utils.py
@@ -79,7 +79,12 @@ def run_sox(infile, outfile, offset, duration):
     if duration:
         cmd = ['sox', infile, outfile, 'trim', str(offset), str(duration)]
     else:
-        cmd = ['sox', infile, outfile, 'trim', str(offset)]
+        cmd = [
+            'sox',
+            infile,
+            outfile,
+            'trim', str(offset),
+        ]
     run(cmd)
 
 

--- a/audiofile/core/utils.py
+++ b/audiofile/core/utils.py
@@ -70,7 +70,12 @@ def run_ffmpeg(infile, outfile, offset, duration):
                   outfile
               ]
     else:
-        cmd = ['ffmpeg', '-ss', str(offset), '-i', infile, outfile]
+        cmd = [
+            'ffmpeg',
+            '-ss', str(offset),
+            '-i', infile,
+            outfile,
+        ]
     run(cmd)
 
 

--- a/audiofile/core/utils.py
+++ b/audiofile/core/utils.py
@@ -82,7 +82,13 @@ def run_ffmpeg(infile, outfile, offset, duration):
 def run_sox(infile, outfile, offset, duration):
     """Convert audio file to WAV file."""
     if duration:
-        cmd = ['sox', infile, outfile, 'trim', str(offset), str(duration)]
+        cmd = [
+            'sox',
+            infile,
+            outfile,
+            'trim', str(offset),
+            str(duration),
+        ]
     else:
         cmd = [
             'sox',

--- a/audiofile/core/utils.py
+++ b/audiofile/core/utils.py
@@ -71,9 +71,9 @@ def run_ffmpeg(infile, outfile, offset, duration):
 def run_sox(infile, outfile, offset, duration):
     """Convert audio file to WAV file."""
     if duration:
-        cmd = ['sox' infile, outfile, 'trim' str(offset) str(duration)]
+        cmd = ['sox', infile, outfile, 'trim', str(offset), str(duration)]
     else:
-        cmd = ['sox' infile, outfile, 'trim' str(offset)]
+        cmd = ['sox', infile, outfile, 'trim', str(offset)]
     run(cmd)
 
 

--- a/audiofile/core/utils.py
+++ b/audiofile/core/utils.py
@@ -1,4 +1,3 @@
-import shlex
 import subprocess
 
 import audeer

--- a/audiofile/core/utils.py
+++ b/audiofile/core/utils.py
@@ -62,7 +62,13 @@ def run(shell_command):
 def run_ffmpeg(infile, outfile, offset, duration):
     """Convert audio file to WAV file."""
     if duration:
-        cmd = ['ffmpeg', '-ss', str(offset), '-i', infile, '-t', str(duration), outfile]
+        cmd = [
+                  'ffmpeg',
+                  '-ss', str(offset),
+                  '-i', infile,
+                  '-t', str(duration),
+                  outfile
+              ]
     else:
         cmd = ['ffmpeg', '-ss', str(offset), '-i', infile, outfile]
     run(cmd)


### PR DESCRIPTION
In windows, the path of a file in a network share start with `\\`. Using `shlex.split` here:
https://github.com/audeering/audiofile/blob/e58253ca7c9a8495bb8a02aba14cc5f95fed83c0/audiofile/core/utils.py#L53
remove a `\` so the file is not found.

Example path: `\\my_share\audio\test.mka` is converted in `\my_share\audio\test.mka`.

This should fix it.