### PR TITLE
CI: fix installation of mediainfo on MacOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,8 +58,8 @@ jobs:
 
     - name: OSX - install ffmpeg/mediainfo
       run: |
-        micromamba install ffmpeg
-        micromamba install libmediainfo
+        brew install ffmpeg
+        brew install media-info
       if: matrix.os == 'macOS-latest'
 
     - name: Windows - install ffmpeg/mediainfo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,8 +58,8 @@ jobs:
 
     - name: OSX - install ffmpeg/mediainfo
       run: |
-        brew install ffmpeg
-        brew install --cask mediainfo
+        micromamba install ffmpeg
+        micromamba install libmediainfo
       if: matrix.os == 'macOS-latest'
 
     - name: Windows - install ffmpeg/mediainfo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,9 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
 
     - name: OSX - install ffmpeg/mediainfo
-      run: brew install ffmpeg mediainfo
+      run: |
+        brew install ffmpeg
+        brew install --cask mediainfo
       if: matrix.os == 'macOS-latest'
 
     - name: Windows - install ffmpeg/mediainfo


### PR DESCRIPTION
~~Makes sure to install `mediainfo` with `brew` using `--cask` as mentioned in~~

![image](https://user-images.githubusercontent.com/173624/216983616-261c871e-8671-49dc-ba33-4ae56c5ee4f4.png)

Using `--cask` did not work, but it seems the package is now simply called [media-info](https://formulae.brew.sh/formula/media-info), and works as expected.