### PR TITLE
DOC: add audresample resample()/remix() examples

### DIFF
--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -144,6 +144,13 @@ def read(
         >>> signal, sampling_rate = read('stereo.wav', duration=0.1)
         >>> signal.shape
         (2, 800)
+        >>> # Use audresample for resampling and remixing
+        >>> import audresample
+        >>> target_rate = 16000
+        >>> signal = audresample.resample(signal, sampling_rate, target_rate)
+        >>> signal = audresample.remix(signal, mixdown=True)
+        >>> signal.shape
+        (1, 1600)
 
     """
     file = audeer.safe_path(file)

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -148,6 +148,8 @@ def read(
         >>> import audresample
         >>> target_rate = 16000
         >>> signal = audresample.resample(signal, sampling_rate, target_rate)
+        >>> signal.shape
+        (2, 1600)
         >>> signal = audresample.remix(signal, mixdown=True)
         >>> signal.shape
         (1, 1600)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,6 +44,7 @@ extensions = [
 ]
 
 intersphinx_mapping = {
+    'audresample': ('https://audeering.github.io/audresample/', None),
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://docs.scipy.org/doc/numpy/', None),
     'soundfile': ('https://pysoundfile.readthedocs.io/en/latest/', None),

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+audresample
 jupyter-sphinx
 sphinx
 sphinx-audeering-theme >=1.2.1

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -60,8 +60,8 @@ You can read the signal:
 
 .. jupyter-execute::
 
-    sig, fs = audiofile.read('noise.flac')
-    print(f'sampling rate: {fs}, signal shape: {sig.shape}')
+    signal, sampling_rate = audiofile.read('noise.flac')
+    print(f'sampling rate: {sampling_rate}, signal shape: {signal.shape}')
 
 If you prefer a workflow
 that returns a 2D signal with channel as the first dimension,
@@ -69,15 +69,15 @@ enforce it with:
 
 .. jupyter-execute::
 
-    sig, fs = audiofile.read('noise.flac', always_2d=True)
-    print(f'sampling rate: {fs}, signal shape: {sig.shape}')
+    signal, sampling_rate = audiofile.read('noise.flac', always_2d=True)
+    print(f'sampling rate: {sampling_rate}, signal shape: {signal.shape}')
 
 If you just want to read from 500 ms to 900 ms of the signal:
 
 .. jupyter-execute::
 
-    sig, fs = audiofile.read('noise.flac', offset=0.5, duration=0.4)
-    print(f'sampling rate: {fs}, signal shape: {sig.shape}')
+    signal, sampling_rate = audiofile.read('noise.flac', offset=0.5, duration=0.4)
+    print(f'sampling rate: {sampling_rate}, signal shape: {signal.shape}')
 
 
 Convert a file
@@ -91,6 +91,37 @@ You can convert any file to WAV using:
     audiofile.samples('noise.wav')
 
 
+Resample/Remix a file
+---------------------
+
+:mod:`audiofile` does not directly support
+resampling or remixing
+of an audio file
+during reading.
+But it can be easily achieved with :mod:`audresample`.
+
+.. jupyter-execute::
+
+    import audresample
+
+    target_rate = 16000
+    signal, sampling_rate = audiofile.read('noise.flac', always_2d=True)
+    signal = audresample.resample(signal, sampling_rate, target_rate)
+    signal = audresample.remix(signal, channels=[0, 0])
+    audiofile.write('noise-remix.flac', signal, target_rate)
+
+    print(f'sampling rate: {audiofile.sampling_rate("noise-remix.flac")}')
+    print(f'channels: {audiofile.channels("noise-remix.flac")}')
+    print(f'samples: {audiofile.samples("noise-remix.flac")}')
+
+
+.. _soundfile: https://pysoundfile.readthedocs.io/
+.. _ffmpeg: https://www.ffmpeg.org/
+.. _sox: http://sox.sourceforge.net/
+.. _mediainfo: https://mediaarea.net/en/MediaInfo/
+
+
+.. Clean up
 .. jupyter-execute::
     :hide-code:
     :hide-output:
@@ -98,9 +129,4 @@ You can convert any file to WAV using:
     import os
     os.remove('noise.wav')
     os.remove('noise.flac')
-
-
-.. _soundfile: https://pysoundfile.readthedocs.io/
-.. _ffmpeg: https://www.ffmpeg.org/
-.. _sox: http://sox.sourceforge.net/
-.. _mediainfo: https://mediaarea.net/en/MediaInfo/
+    os.remove('noise-remix.flac')

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -61,7 +61,9 @@ You can read the signal:
 .. jupyter-execute::
 
     signal, sampling_rate = audiofile.read('noise.flac')
-    print(f'sampling rate: {sampling_rate}, signal shape: {signal.shape}')
+
+    print(f'sampling rate: {sampling_rate}')
+    print(f'signal shape: {signal.shape}')
 
 If you prefer a workflow
 that returns a 2D signal with channel as the first dimension,
@@ -70,14 +72,18 @@ enforce it with:
 .. jupyter-execute::
 
     signal, sampling_rate = audiofile.read('noise.flac', always_2d=True)
-    print(f'sampling rate: {sampling_rate}, signal shape: {signal.shape}')
+
+    print(f'sampling rate: {sampling_rate}')
+    print(f'signal shape: {signal.shape}')
 
 If you just want to read from 500 ms to 900 ms of the signal:
 
 .. jupyter-execute::
 
     signal, sampling_rate = audiofile.read('noise.flac', offset=0.5, duration=0.4)
-    print(f'sampling rate: {sampling_rate}, signal shape: {signal.shape}')
+
+    print(f'sampling rate: {sampling_rate}')
+    print(f'signal shape: {signal.shape}')
 
 
 Convert a file
@@ -87,8 +93,11 @@ You can convert any file to WAV using:
 
 .. jupyter-execute::
 
+    import audeer
+
     audiofile.convert_to_wav('noise.flac', 'noise.wav')
-    audiofile.samples('noise.wav')
+
+    audeer.list_file_names('.', filetype='wav', basenames=True)
 
 
 Resample/Remix a file
@@ -111,8 +120,7 @@ But it can be easily achieved with :mod:`audresample`.
     audiofile.write('noise-remix.flac', signal, target_rate)
 
     print(f'sampling rate: {audiofile.sampling_rate("noise-remix.flac")}')
-    print(f'channels: {audiofile.channels("noise-remix.flac")}')
-    print(f'samples: {audiofile.samples("noise-remix.flac")}')
+    print(f'signal shape: {signal.shape}')
 
 
 .. _soundfile: https://pysoundfile.readthedocs.io/

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+audresample
 pytest
 pytest-cov
 pytest-doctestplus


### PR DESCRIPTION
Closes #110 

This extends the usage documentation and the docstring example of `audiofile.read()` to show how to resample and remix a file/signal with `audresample`.

## `audiofile.read()`

![image](https://user-images.githubusercontent.com/173624/217466470-755c9ab4-1657-4752-b4b0-cf42d8562dc4.png)

## `docs/usage.rst`

![image](https://user-images.githubusercontent.com/173624/217466301-475e6955-5ad7-411d-8953-cd44695c1817.png)

I also adjusted the output of some of the existing sub-sections:

![image](https://user-images.githubusercontent.com/173624/217466229-c12205cf-7dd7-4c91-a853-d26259ddccc3.png)