### PR TITLE
Fix: make sure normalize is applied in convert_to_wav()

### DIFF
--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -100,7 +100,14 @@ def convert_to_wav(
         offset=offset,
         duration=duration,
     )
-    write(outfile, signal, sampling_rate, bit_depth=bit_depth, **kwargs)
+    write(
+        outfile,
+        signal,
+        sampling_rate,
+        bit_depth=bit_depth,
+        normalize=normalize,
+        **kwargs,
+    )
     return outfile
 
 

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -344,14 +344,17 @@ def test_convert_to_wav(tmpdir, normalize, bit_depth, file_extension):
     converted_signal, converted_sampling_rate = af.read(outfile)
     assert converted_sampling_rate == sampling_rate
     if normalize:
-        assert converted_signal.max() == 1
-        assert converted_signal.min() == -1
-    abs_difference = np.abs(converted_signal - signal).max()
+        assert converted_signal.max() > 0.98
+        assert converted_signal.max() <= 1.0
+        assert converted_signal.min() < -0.98
+        assert converted_signal.min() >= -1.0
     if file_extension == 'mp3':
         assert af.bit_depth(outfile) == bit_depth
         # Don't compare signals for MP3
         # as duration differs as well
-    elif file_extension == 'ogg':
+    else:
+        abs_difference = np.abs(converted_signal - signal).max()
+    if file_extension == 'ogg':
         assert af.bit_depth(outfile) == bit_depth
         if normalize:
             assert abs_difference < 0.06 + magnitude_offset

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -344,9 +344,11 @@ def test_convert_to_wav(tmpdir, normalize, bit_depth, file_extension):
     converted_signal, converted_sampling_rate = af.read(outfile)
     assert converted_sampling_rate == sampling_rate
     if normalize:
-        assert converted_signal.max() > 0.98
+        # The actual maximum/minimum value can vary
+        # based on the used codec/format
+        assert converted_signal.max() > 0.95
         assert converted_signal.max() <= 1.0
-        assert converted_signal.min() < -0.98
+        assert converted_signal.min() < -0.95
         assert converted_signal.min() >= -1.0
     if file_extension == 'mp3':
         assert af.bit_depth(outfile) == bit_depth


### PR DESCRIPTION
Closes #116 

This adds a test to check that the `normalize` argument in `audiofile.convert_to_wav()` is passed on to `audiofile.write()`
and fixes the implementation.
