### PR TITLE
CI: fix doc test and doc publishing

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,43 @@
+name: Documentation
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+        python-version: [ '3.8' ]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Ubuntu - install libsndfile
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libsndfile1
+
+    - name: Install package
+      run: |
+        pip install -r requirements.txt
+
+    # DOCS
+    - name: Install doc requirements
+      run: pip install -r docs/requirements.txt
+
+    - name: Test building documentation
+      run: python -m sphinx docs/ docs/_build/ -b html -W
+
+    - name: Check links in documentation
+      run: python -m sphinx docs/ docs/_build/ -b linkcheck -W

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,6 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
         python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
-        tasks: [ tests ]
         sox: [ sox, no-sox ]  # sox binary present or not
 
     steps:
@@ -71,9 +70,8 @@ jobs:
         pip install -r requirements.txt
 
     # TESTS
-    - name: Install tests requirements
+    - name: Install test requirements
       run: pip install -r tests/requirements.txt
-      if: matrix.tasks == 'tests'
 
     - name: Show sox version
       run: |
@@ -81,24 +79,10 @@ jobs:
 
     - name: Test with pytest
       run: python -m pytest
-      if: matrix.tasks == 'tests'
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
-      if: matrix.tasks == 'tests' && matrix.os == 'ubuntu-latest'
-
-    # DOCS
-    - name: Install docs requirements
-      run: pip install -r docs/requirements.txt
-      if: matrix.tasks == 'docs'
-
-    - name: Test building documentation
-      run: python -m sphinx docs/ docs/_build/ -b html -W
-      if: matrix.tasks == 'docs'
-
-    - name: Check links in documentation
-      run: python -m sphinx docs/ docs/_build/ -b linkcheck -W
-      if: matrix.tasks == 'docs'
+      if: matrix.os == 'ubuntu-latest'

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 audplot
 audresample
 jupyter-sphinx
+pytest
 sphinx
 sphinx-audeering-theme >=1.2.1
 sphinx_autodoc_typehints


### PR DESCRIPTION
This re-enables the test for building the documentation and add `pytest` to `docs/requriements.txt` as it is now also needed when building the docs, due to `audiofile/core/conftest.py`.

This error has let the last version failed during publication: https://github.com/audeering/audiofile/actions/runs/4162346735/jobs/7201405965