### PR TITLE
Evenly round offset/duration to samples

### DIFF
--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -6,6 +6,7 @@ import numpy as np
 import soundfile
 
 import audeer
+import audmath
 
 from audiofile.core.convert import convert
 from audiofile.core.utils import MAX_CHANNELS
@@ -379,7 +380,7 @@ def read(
     # and returned immediately
     # if duration == 0
     if duration is not None and duration != 0:
-        duration = to_samples(duration, sampling_rate)
+        duration = audmath.samples(duration, sampling_rate)
     if duration == 0:
         from audiofile.core.info import channels as get_channels
         channels = get_channels(file)
@@ -389,7 +390,7 @@ def read(
             signal = np.zeros((0,))
         return signal, sampling_rate
     if offset is not None and offset != 0:
-        offset = to_samples(offset, sampling_rate)
+        offset = audmath.samples(offset, sampling_rate)
     else:
         offset = 0
 

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -422,7 +422,7 @@ def read(
             )
     else:
         start = offset
-        # duration == 0 is handled further above wit immediate return
+        # duration == 0 is handled further above with immediate return
         if duration is not None:
             stop = duration + start
         else:

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -407,7 +407,7 @@ def read(
         # libsndfile see https://github.com/erikd/libsndfile/issues/258.
         with tempfile.TemporaryDirectory(prefix='audiofile') as tmpdir:
             tmpfile = os.path.join(tmpdir, 'tmp.wav')
-            # offset and duration has to be given in seconds
+            # offset and duration have to be given in seconds
             if offset != 0:
                 offset /= sampling_rate
             if duration is not None and duration != 0:

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -51,10 +51,9 @@ def convert_to_wav(
     e.g. for a file containing the signal ``[0, 1, 2]``,
     ``duration=2``, ``offset=-4`` will return ``[0]``.
 
-    When ``duration`` and/or ``offset``
-    are not provided as samples
-    their duration values
-    are evenly rounded to samples.
+    ``duration`` and ``offset``
+    are evenly rounded
+    after conversion to samples.
 
     It then uses :func:`soundfile.write` to write the WAV file,
     which limits the number of supported channels to 65535.
@@ -156,10 +155,9 @@ def read(
     e.g. for a file containing the signal ``[0, 1, 2]``,
     ``duration=2``, ``offset=-4`` will return ``[0]``.
 
-    When ``duration`` and/or ``offset``
-    are not provided as samples
-    their duration values
-    are evenly rounded to samples.
+    ``duration`` and ``offset``
+    are evenly rounded
+    after conversion to samples.
 
     Args:
         file: file name of input audio file

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -51,6 +51,11 @@ def convert_to_wav(
     e.g. for a file containing the signal ``[0, 1, 2]``,
     ``duration=2``, ``offset=-4`` will return ``[0]``.
 
+    When ``duration`` and/or ``offset``
+    are not provided as samples
+    their duration values
+    are evenly rounded to samples.
+
     It then uses :func:`soundfile.write` to write the WAV file,
     which limits the number of supported channels to 65535.
 

--- a/audiofile/core/utils.py
+++ b/audiofile/core/utils.py
@@ -129,11 +129,3 @@ def run_sox(infile, outfile, offset, duration):
             'trim', str(offset),
         ]
     run(cmd)
-
-
-def to_samples(
-        duration: float,
-        sampling_rate: int,
-) -> int:
-    r"""Convert duration from seconds to samples."""
-    return int(round(duration * sampling_rate))

--- a/audiofile/core/utils.py
+++ b/audiofile/core/utils.py
@@ -129,3 +129,11 @@ def run_sox(infile, outfile, offset, duration):
             'trim', str(offset),
         ]
     run(cmd)
+
+
+def to_samples(
+        duration: float,
+        sampling_rate: int,
+) -> int:
+    r"""Convert duration from seconds to samples."""
+    return int(round(duration * sampling_rate))

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -1257,8 +1257,7 @@ def test_read_duration_and_offset_rounding(tmpdir, offset, duration, expected):
 
     if len(expected) == 0:
         # duration of 0 is handled inside af.read()
-        # even when duration is only 0
-        # after rounding
+        # even when duration is only 0 after rounding
         # as ffmpeg cannot handle those cases
         return 0
 

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -439,7 +439,7 @@ def test_wav(tmpdir, bit_depth, duration, sampling_rate, channels, always_2d):
             duration=duration,
             always_2d=always_2d,
         )
-        assert _samples(sig) == int(round(duration * sampling_rate))
+        assert _samples(sig) == round(duration * sampling_rate)
 
 
 @pytest.mark.parametrize('magnitude', [0.01, 0.1, 1])

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -1264,13 +1264,18 @@ def test_read_duration_and_offset_rounding(tmpdir, offset, duration, expected):
 
     # sox
     convert_file = str(tmpdir.join('signal-sox.wav'))
-    af.core.utils.run_sox(file, convert_file, offset, duration)
-    signal, _ = af.read(convert_file)
-    np.testing.assert_allclose(
-        signal,
-        np.array(expected, dtype=np.float32),
-        rtol=1e-03,
-    )
+    try:
+        af.core.utils.run_sox(file, convert_file, offset, duration)
+        signal, _ = af.read(convert_file)
+        np.testing.assert_allclose(
+            signal,
+            np.array(expected, dtype=np.float32),
+            rtol=1e-03,
+        )
+    except FileNotFoundError:
+        # When testing without an installation of sox
+        pass
+
     # ffmpeg
     convert_file = str(tmpdir.join('signal-ffmpeg.wav'))
     af.core.utils.run_ffmpeg(file, convert_file, offset, duration)


### PR DESCRIPTION
Related to https://github.com/audeering/audinterface/issues/123

This changes how the `offset` and `duration` values of `audiofile.read()` and `audiofile.convert_to_wav()` are rounded towards samples when not given as samples.

Before those values were evenly rounded (`int(round(...))`) for non SND files (e.g. MP3, MP4), but upwardly rounded (`int(np.ceil(...))`) for SND files (WAV, FLAC, OGG). See https://en.wikipedia.org/wiki/Rounding for a discussion of the used terminology.
Now they are **evenly rounded in both cases**. This means for a sampling rate of 10 Hz, a duration of 0.11 s would return a single sample, whereas before it would return 2 samples. We now return 2 samples for a duration of 0.15 s:

```python
>>> sampling_rate = 10  # Hz

>>> duration = 0.11  # s

>>> int(round(duration * sampling_rate))
1

>>> int(np.ceil(duration * sampling_rate))
2

>>> duration = 0.15  # s

>>> int(round(duration * sampling_rate))
2
```

The new behavior is in line with `sox` and makes also more sense in real applications as mostly we are dealing with rounding there due to problems with machine precision, e.g.

```python
>>> int(np.ceil(1.14 * 16000))
18240

>>> int(round(1.14 * 16000))
18240
```

but (see also https://github.com/audeering/audinterface/issues/123)

```python
>>> int(np.ceil(pd.Timedelta('0 days 00:00:01.140000').total_seconds() * 16000))
18241

>>> int(round(pd.Timedelta('0 days 00:00:01.140000').total_seconds() * 16000))
18240
```

I added the rounding behavior to the docstring of `audiofile.read()` and `audiofile.convert_to_wav()`. Compare [numpy.round](https://numpy.org/doc/stable/reference/generated/numpy.round.html#numpy.round), that also uses "evenly round".

![image](https://github.com/audeering/audiofile/assets/173624/3f5f9ff0-b09d-4fcf-af69-07da1533a146)

In addition, I added a test checking the expected behavior that is failing for the current `main` branch.