### PR TITLE
CI: use setup-micromamba GitHub Action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   build:
 
     # Make sure .bashrc is read by shell for micromamba,
-    # see https://github.com/mamba-org/provision-with-micromamba#important
+    # see https://github.com/mamba-org/setup-micromamba#about-login-shells
     defaults:
       run:
         shell: bash -l {0}
@@ -26,12 +26,11 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }} with Micromamba
-      uses: mamba-org/provision-with-micromamba@main
+      uses: mamba-org/setup-micromamba@v1
       with:
-        cache-env: true
-        environment-file: false
+        cache-environment: true
         environment-name: venv
-        extra-specs: |
+        create-args: |
           pip
           python=${{ matrix.python-version }}
         channels: conda-forge

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,6 @@ jobs:
         create-args: |
           pip
           python=${{ matrix.python-version }}
-        channels: conda-forge
 
     - name: Activate Python virtual environment
       run: micromamba activate venv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       with:
         cache-environment: true
         environment-name: venv
-        create-args: |
+        create-args: >-
           pip
           python=${{ matrix.python-version }}
 


### PR DESCRIPTION
As stated in https://github.com/mamba-org/provision-with-micromamba the GitHub Action `provision-with-micromamba` is deprecated and replaced by [mamba-org/setup-micromamba](https://github.com/mamba-org/setup-micromamba).