### PR TITLE
DOC: add ipykernel as dependency

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 audplot
 audresample
+ipykernel
 jupyter-sphinx
 pytest
 sphinx


### PR DESCRIPTION
`jupyter-sphinx` has a bug and does not specify `ipykernel` as its dependency.