### PR TITLE
CI: simplify changelog parsing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,11 +51,6 @@ jobs:
       run: |
         # Get bullet points from last CHANGELOG entry
         CHANGELOG=$(git diff -U0 HEAD^ HEAD | grep '^[+][\* ]' | sed 's/\+//')
-        # Support for multiline, see
-        # https://github.com/actions/create-release/pull/11#issuecomment-640071918
-        CHANGELOG="${CHANGELOG//'%'/'%25'}"
-        CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
-        CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
         echo "Got changelog: $CHANGELOG"
         echo "body=$CHANGELOG" >> $GITHUB_OUTPUT
     - name: Create release on Github


### PR DESCRIPTION
Before we were replacing new line and other characters [to be compatible with set-output](https://github.com/actions/create-release/issues/25#issuecomment-562687270). But as set-output is now deprecated we are no longer using it, the current approach leads to malformed changelog lists on the Github releases page.

Most likely, we can just remove the lines replacing characters and get the desired output.