### PR TITLE
Use libsndfile for reading MP3 files

### DIFF
--- a/audiofile/core/utils.py
+++ b/audiofile/core/utils.py
@@ -14,7 +14,12 @@ MAX_CHANNELS = {
 }
 r"""Maximum number of channels per format."""
 
-SNDFORMATS = ['wav', 'flac', 'ogg']
+SNDFORMATS = [
+    'wav',
+    'flac',
+    'mp3',  # requires libsndfile >=1.1.0
+    'ogg',
+]
 r"""File formats handled by soundfile"""
 
 

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -216,7 +216,7 @@ def test_empty_file(tmpdir, convert, empty_file):
 
 @pytest.mark.parametrize(
     'empty_file',
-    ('bin', 'mp3'),
+    ('bin', 'mp4'),
     indirect=True,
 )
 def test_missing_binaries(tmpdir, hide_system_path, empty_file):


### PR DESCRIPTION
Closes #119 

This uses `libsndfile` to read MP3 files. It requires `libsndfile >=1.1.0`, which is also a limitation as we still have PCs around with lower versions. I would try to avoid handling MP3 differently depending on the installed `libsndfile` version, and maybe just wait a few more month until the old versions have finally disappeared.

NOTE: we should also update the benchmarks to see if it is faster.