### PR TITLE
DOC: fix links to soundfile documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ to ensure that duration and number of samples match.
 .. _reading speed: https://audeering.github.io/audiofile/benchmark.html
 .. _sox: http://sox.sourceforge.net/
 .. _virtualenv: https://virtualenv.pypa.io/
-.. _soundfile: https://pysoundfile.readthedocs.io/
+.. _soundfile: https://python-soundfile.readthedocs.io/
 
 .. |tests| image:: https://github.com/audeering/audiofile/workflows/Test/badge.svg
     :target: https://github.com/audeering/audiofile/actions?query=workflow%3ATest

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,7 @@ intersphinx_mapping = {
     'audresample': ('https://audeering.github.io/audresample/', None),
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://docs.scipy.org/doc/numpy/', None),
-    'soundfile': ('https://pysoundfile.readthedocs.io/en/latest/', None),
+    'soundfile': ('https://python-soundfile.readthedocs.io/en/latest/', None),
 }
 
 # Ignore package dependencies during building the docs

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -123,7 +123,7 @@ But it can be easily achieved with :mod:`audresample`.
     print(f'signal shape: {signal.shape}')
 
 
-.. _soundfile: https://pysoundfile.readthedocs.io/
+.. _soundfile: https://python-soundfile.readthedocs.io/
 .. _ffmpeg: https://www.ffmpeg.org/
 .. _sox: http://sox.sourceforge.net/
 .. _mediainfo: https://mediaarea.net/en/MediaInfo/


### PR DESCRIPTION
The URL of the `soundfile` documentation on Read The Docs has changed to https://python-soundfile.readthedocs.io/.