### PR TITLE
DOC: add README for benchmark code

### DIFF
--- a/docs/benchmark/README.md
+++ b/docs/benchmark/README.md
@@ -1,19 +1,14 @@
 # audiofile benchmarks
 
+
 ## Installation
 
-Make sure build dependencies are installed,
-e.g. under Ubuntu:
+Install all system dependencies on Ubuntu,
+create virtual environment
+and install Python packages:
 
 ```bash
-$ sudo apt install libcairo2-dev libmad0-dev libgirepository1.0-dev sox libsox-fmt-mp3 ffmpeg mediainfo
-```
-
-Then create a virtual environment
-and install the Python packages:
-
-```bash
-$ pip install -r requirements.txt.lock
+$ bash install_dependencies.sh
 ```
 
 ## Usage

--- a/docs/benchmark/README.md
+++ b/docs/benchmark/README.md
@@ -1,0 +1,31 @@
+# audiofile benchmarks
+
+## Installation
+
+Make sure build dependencies are installed,
+e.g. under Ubuntu:
+
+```bash
+$ sudo apt install libcairo2-dev libmad0-dev libgirepository1.0-dev sox libsox-fmt-mp3 ffmpeg mediainfo
+```
+
+Then create a virtual environment
+and install the Python packages:
+
+```bash
+$ pip install -r requirements.txt.lock
+```
+
+## Usage
+
+First generate the needed audio data:
+
+```bash
+$ bash generate_audio.sh
+```
+
+Execute the benchmarks with:
+
+```bash
+$ bash run.sh
+```

--- a/docs/benchmark/benchmark_info.py
+++ b/docs/benchmark/benchmark_info.py
@@ -64,9 +64,16 @@ if __name__ == "__main__":
         'sox',
     ]
 
+    audio_walk = sorted(os.walk('AUDIO'))
+    if len(audio_walk) == 0:
+        raise RuntimeError(
+            'No audio files were found.\n'
+            "Make sure you executed 'bash generate_audio.sh'"
+        )
+
     for lib in libs:
         print(f"Benchmark metadata {args.ext} with {lib}")
-        for root, dirs, fnames in sorted(os.walk('AUDIO')):
+        for root, dirs, fnames in audio_walk:
             for audio_dir in dirs:
 
                 # MP4 and MP3 is not supported by all libraries

--- a/docs/benchmark/benchmark_read.py
+++ b/docs/benchmark/benchmark_read.py
@@ -70,9 +70,16 @@ if __name__ == "__main__":
         'soundfile',
     ]
 
+    audio_walk = sorted(os.walk('AUDIO'))
+    if len(audio_walk) == 0:
+        raise RuntimeError(
+            'No audio files were found.\n'
+            "Make sure you executed 'bash generate_audio.sh'"
+        )
+
     for lib in libs:
         print(f"Benchmark read {args.ext} with {lib}")
-        for root, dirs, fnames in sorted(os.walk('AUDIO')):
+        for root, dirs, fnames in audio_walk:
             for audio_dir in dirs:
 
                 # Not all libraries support all file formats

--- a/docs/benchmark/install_dependencies.sh
+++ b/docs/benchmark/install_dependencies.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
-# Libraries for audioread
-sudo apt-get install -y libmad0-dev sox ffmpeg
-sudo apt-get install -y libavresample-dev libswresample-dev libavutil-dev
-sudo apt-get install -y libavcodec-dev libavformat-dev libsamplerate0-dev
+# Libraries
+sudo apt install -y sox ffmpeg libsox-fmt-mp3
+sudo apt install -y libavresample-dev libswresample-dev libavutil-dev
+sudo apt install -y libavcodec-dev libavformat-dev libsamplerate0-dev
+sudo apt install -y libcairo2-dev libmad0-dev libgirepository1.0-dev
 
 # Create and activate Python virtual environment
 if command -v deactivate &> /dev/null

--- a/docs/benchmark/utils.py
+++ b/docs/benchmark/utils.py
@@ -16,10 +16,11 @@ class DF_writer(object):
 
     def append(self, **row_data):
         if set(self.columns) == set(row_data):
-            self.df = pd.concat(
-                [self.df, pd.DataFrame.from_records([row_data])],
-                ignore_index=True,
-            )
+            new_df = pd.DataFrame.from_records([row_data])
+            if len(self.df) == 0:
+                self.df = new_df
+            else:
+                self.df = pd.concat([self.df, new_df], ignore_index=True)
 
 
 def plot_results(df, target_lib="", audio_format="", ext="png"):


### PR DESCRIPTION
This documents how to prepare and execute the benchmark. And updates the benchmark code to avoid deprecation warnings and add a hint if the audio files for the benchmark are missing.

**NOTE**: this is also documented in the online documentation at https://audeering.github.io/audiofile/benchmark.html#running-the-benchmark, but it might be that a user does not find it when trying to run the benchmark locally.

![image](https://github.com/audeering/audiofile/assets/173624/678676ff-7ae6-4797-a5d9-4ae46a6c7ec4)
