### PR TITLE
Add support for writing to MP3 files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ ffmpeg_,
 sox_,
 and mediainfo_.
 In addition,
-it can write WAV, FLAC, and OGG files.
+it can write WAV, FLAC, MP3, and OGG files.
 
 Have a look at the installation_ and usage_ instructions as a starting point.
 

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -451,9 +451,10 @@ def write(
     """Write (normalized) audio files.
 
     Save audio data provided as an array of shape ``[channels, samples]``
-    to a WAV, FLAC, or OGG file.
+    to a WAV, FLAC, MP3, or OGG file.
     ``channels`` can be up to 65535 for WAV,
     255 for OGG,
+    2 for MP3,
     and 8 for FLAC.
     For monaural audio the array can be one-dimensional.
 
@@ -461,7 +462,7 @@ def write(
 
     Args:
         file: file name of output audio file.
-            The format (WAV, FLAC, OGG) will be inferred from the file name
+            The format (WAV, FLAC, MP3, OGG) will be inferred from the file name
         signal: audio data to write
         sampling_rate: sample rate of the audio data
         bit_depth: bit depth of written file in bit,

--- a/audiofile/core/utils.py
+++ b/audiofile/core/utils.py
@@ -10,6 +10,7 @@ import audmath
 MAX_CHANNELS = {
     'wav': 65535,
     'ogg': 255,
+    'mp3': 2,
     'flac': 8,
 }
 r"""Maximum number of channels per format."""

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -7,7 +7,7 @@ ffmpeg_,
 sox_,
 and mediainfo_,
 if those are available on your system.
-In addition, it can create WAV, FLAC, or OGG files.
+In addition, it can create WAV, FLAC, MP3, or OGG files.
 
 
 Write a file

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -303,10 +303,7 @@ def test_convert_to_wav(tmpdir, normalize, bit_depth, file_extension):
         channels=channels,
     )
     infile = str(tmpdir.join(f'signal.{file_extension}'))
-    if file_extension == 'mp3':
-        af.write(infile, signal, sampling_rate)
-    else:
-        af.write(infile, signal, sampling_rate, bit_depth=bit_depth)
+    af.write(infile, signal, sampling_rate, bit_depth=bit_depth)
     if file_extension == 'wav':
         error_msg = (
             f"'{infile}' would be overwritten. "

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -458,7 +458,7 @@ def test_magnitude(tmpdir, magnitude, normalize, bit_depth, sampling_rate):
 @pytest.mark.parametrize('magnitude', [0.01])
 def test_file_type(tmpdir, file_type, magnitude, sampling_rate, channels):
 
-    # Skip unallowed combination
+    # Skip unallowed combinations
     if file_type == 'flac' and channels > 8:
         return None
     if file_type == 'mp3' and channels > 2:

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -1,6 +1,5 @@
 import os
 import re
-import subprocess
 
 import numpy as np
 from numpy.testing import assert_allclose


### PR DESCRIPTION
After introducing read support for MP3 file with `libsndfile` in #145, this pull requests uses `libsndfile` to write MP3 files.
The most important part is that we add `'mp3'` as supported part to `MAX_CHANNELS` to not get an error when trying to write it. Otherwise, we just need to pass it on to `soundfile` as with reading.

So the main part of this pull request is updating the documentation and simplifying the tests as we no longer need ffmpeg` to create MP3 files in the tests.

![image](https://github.com/audeering/audiofile/assets/173624/58b6bd40-8ac9-425c-841f-7a14084c6994)
