### PR TITLE
DOC: fix supported signal shapes in write()

### DIFF
--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -450,8 +450,9 @@ def write(
 ):
     """Write (normalized) audio files.
 
-    Save audio data provided as an array of shape ``[channels, samples]``
-    to a WAV, FLAC, MP3, or OGG file.
+    Save audio data provided as an array of shape ``(channels, samples)``
+    or ``(samples,)``
+    to a WAV, FLAC, NP3, or OGG file.
     ``channels`` can be up to 65535 for WAV,
     255 for OGG,
     2 for MP3,


### PR DESCRIPTION
We do not only allow for two dimensional signals in `audiofile.write()`, but also for single dimensional if only a single channel is given.

![image](https://github.com/audeering/audiofile/assets/173624/6c188ee4-f7eb-4236-8672-1083b531ef71)
