### PR TITLE
Depend on audmath>=1.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 ]
 dependencies = [
     'audeer',
-    'audmath >=1.2.1',
+    'audmath >=1.3.0',
     'numpy',
     'soundfile >=0.12.1',  # MP3 support with bundled libsndfile
 ]


### PR DESCRIPTION
`audiofile` uses `audmath.samples()` under the hood, which was only introduced in `audmath` v1.3.0, so we need to require at least that version of `audmath`.