### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
         sox: [ sox, no-sox ]  # sox binary present or not
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Topic :: Scientific/Engineering',
     'Topic :: Multimedia :: Sound/Audio',
 ]


### PR DESCRIPTION
Adds Python 3.13 as supported version to the Python package and enables tests for it in Ubuntu runners.

## Summary by Sourcery

Add support for Python 3.13.

Build:
- Add Python 3.13 to the list of supported Python versions in the project configuration.

CI:
- Add Python 3.13 to the test matrix in the CI workflow.