### PR TITLE
Remove support for Python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
         sox: [ sox, no-sox ]  # sox binary present or not
 
     steps:

--- a/audiofile/core/info.py
+++ b/audiofile/core/info.py
@@ -1,9 +1,10 @@
 """Read, write, and get information about audio files."""
 
+from __future__ import annotations
+
 import os
 import subprocess
 import tempfile
-import typing
 
 import soundfile
 
@@ -17,7 +18,7 @@ from audiofile.core.utils import file_extension
 from audiofile.core.utils import run
 
 
-def bit_depth(file: str) -> typing.Optional[int]:
+def bit_depth(file: str) -> int | None:
     r"""Bit depth of audio file.
 
     For lossy audio files,

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import os
 import tempfile
-import typing
 
 import numpy as np
 import soundfile
@@ -18,8 +19,8 @@ from audiofile.core.utils import file_extension
 def convert_to_wav(
     infile: str,
     outfile: str = None,
-    offset: typing.Union[float, int, str, np.timedelta64] = None,
-    duration: typing.Union[float, int, str, np.timedelta64] = None,
+    offset: float | int | str | np.timedelta64 = None,
+    duration: float | int | str | np.timedelta64 = None,
     bit_depth: int = 16,
     normalize: bool = False,
     overwrite: bool = False,
@@ -122,12 +123,12 @@ def convert_to_wav(
 
 def read(
     file: str,
-    duration: typing.Union[float, int, str, np.timedelta64] = None,
-    offset: typing.Union[float, int, str, np.timedelta64] = None,
+    duration: float | int | str | np.timedelta64 = None,
+    offset: float | int | str | np.timedelta64 = None,
     always_2d: bool = False,
     dtype: str = "float32",
     **kwargs,
-) -> typing.Tuple[np.array, int]:
+) -> tuple[np.array, int]:
     """Read audio file.
 
     It uses :func:`soundfile.read` for WAV, FLAC, MP3, and OGG files.

--- a/audiofile/core/utils.py
+++ b/audiofile/core/utils.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import os
 import subprocess
-import typing
 
 import numpy as np
 
@@ -57,8 +58,8 @@ def broken_file_error(file: str) -> Exception:
 
 
 def duration_in_seconds(
-    duration: typing.Union[float, int, str, np.timedelta64],
-    sampling_rate: typing.Union[float, int],
+    duration: float | int | str | np.timedelta64,
+    sampling_rate: float | int,
 ) -> np.floating:
     r"""Duration in seconds.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
@@ -31,6 +30,7 @@ classifiers = [
     'Topic :: Scientific/Engineering',
     'Topic :: Multimedia :: Sound/Audio',
 ]
+requires-python = '>=3.9'
 dependencies = [
     'audeer',
     'audmath >=1.3.0',


### PR DESCRIPTION
Removes support for Python 3.8 and updates syntax of code to stop using `typing`.

## Summary by Sourcery

Remove support for Python 3.8.

Build:
- Remove Python 3.8 from the CI build matrix.

Chores:
- Update the required Python version to 3.9 in `pyproject.toml`.