### PR TITLE
Remove support for Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
-        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
         sox: [ sox, no-sox ]  # sox binary present or not
 
     steps:

--- a/audiofile/core/info.py
+++ b/audiofile/core/info.py
@@ -1,7 +1,5 @@
 """Read, write, and get information about audio files."""
 
-from __future__ import annotations
-
 import os
 import subprocess
 import tempfile

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 import tempfile
 

--- a/audiofile/core/utils.py
+++ b/audiofile/core/utils.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 import subprocess
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
@@ -30,7 +29,7 @@ classifiers = [
     'Topic :: Scientific/Engineering',
     'Topic :: Multimedia :: Sound/Audio',
 ]
-requires-python = '>=3.9'
+requires-python = '>=3.10'
 dependencies = [
     'audeer',
     'audmath >=1.3.0',


### PR DESCRIPTION
Remove support for Python 3.9.

## Summary by Sourcery

Remove support for Python 3.9 by updating project metadata and CI configuration.

Build:
- Bump minimum Python requirement to 3.10 and remove Python 3.9 classifier in project metadata

CI:
- Remove Python 3.9 from the GitHub Actions test matrix