### PR TITLE
Add support for Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
-        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
         sox: [ sox, no-sox ]  # sox binary present or not
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Topic :: Scientific/Engineering',
     'Topic :: Multimedia :: Sound/Audio',
 ]


### PR DESCRIPTION
Add support and tests for Python 3.14.

## Summary by Sourcery

Support Python 3.14 by updating the CI workflow and package metadata

Enhancements:
- Add support for Python 3.14

CI:
- Include Python 3.14 in the GitHub Actions test matrix

Documentation:
- Add Python 3.14 to package classifiers in pyproject.toml