### PR TITLE
TST: update codespell and ruff in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,13 +13,13 @@ default_language_version:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.0
+    rev: v0.13.3
     hooks:
       - id: ruff
         args: [ --fix ]
       - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
         additional_dependencies:

--- a/audiofile/core/io.py
+++ b/audiofile/core/io.py
@@ -484,7 +484,7 @@ def write(
         if bit_depth not in bit_depths:
             raise RuntimeError(
                 f'"bit_depth" has to be one of '
-                f'{", ".join([str(b) for b in bit_depths])}.'
+                f"{', '.join([str(b) for b in bit_depths])}."
             )
         subtype = depth_mapping[bit_depth]
     else:

--- a/docs/benchmark/plot.py
+++ b/docs/benchmark/plot.py
@@ -105,5 +105,5 @@ for package in ["read", "info"]:
             plt.title(f"Access metadata, average over {number_of_files} files")
         else:
             plt.title(f"Read file, average over {number_of_files} files")
-        g.savefig(f'results/benchmark_{"-".join(exts)}_{package}.png')
+        g.savefig(f"results/benchmark_{'-'.join(exts)}_{package}.png")
         plt.close()

--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -1308,6 +1308,6 @@ def test_write_errors():
     )
     with pytest.raises(RuntimeError, match=expected_error):
         write_and_read("test.ogg", np.zeros((256, 100)), sampling_rate)
-    expected_error = "The maximum number of allowed channels " "for 'wav' is 65535."
+    expected_error = "The maximum number of allowed channels for 'wav' is 65535."
     with pytest.raises(RuntimeError, match=expected_error):
         write_and_read("test.wav", np.zeros((65536, 100)), sampling_rate)


### PR DESCRIPTION
Update to latest `ruff` and `codespell` versions in pre-commit.

## Summary by Sourcery

Bump ruff and codespell to their latest versions in pre-commit configuration and apply resulting automated fixes for f-string quoting and test message formatting.

Enhancements:
- Update ruff pre-commit hook to v0.13.3
- Update codespell pre-commit hook to v2.4.1
- Normalize f-string quoting in core code and benchmark plots
- Simplify redundant string concatenation in test error messages