### PR TITLE
TST: extend missing file tests

### DIFF
--- a/tests/test_audiofile.py
+++ b/tests/test_audiofile.py
@@ -245,6 +245,7 @@ def test_missing_file(tmpdir, ext):
         af.duration(missing_file, sloppy=True)
     with pytest.raises(expected_error):
         af.samples(missing_file)
+    # bit_depth is only applicable to 'wav' and 'flac' formats
     if ext in ["wav", "flac"]:
         with pytest.raises(expected_error):
             af.bit_depth(missing_file)


### PR DESCRIPTION
Closes #154 

This adds tests for all functions to ensure it raises `RuntimeError` when a missing file is given.

In #154 it was reported that `soundfile.LibsndfileError` is raises instead, but this is a subclass of `RuntimeError` and is not in conflict what we write in the documentation.

## Summary by Sourcery

Extend missing-file tests in test_audiofile to cover samples and bit_depth functions, ensuring they raise RuntimeError for non-existent files

Tests:
- Add tests to verify that samples raises RuntimeError for missing files
- Add conditional tests to verify that bit_depth raises RuntimeError for missing wav and flac files