### PR TITLE
Include only audiofile* in Python package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ build-backend = 'setuptools.build_meta'
 
 # ----- codespell ---------------------------------------------------------
 [tool.codespell]
-builtin = 'clear,rare,informal,usage,names'
 skip = './audiofile.egg-info,./build,./docs/api,./docs/_templates,./docs/benchmark'
 uri-ignore-words-list = 'master,ba'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,6 +220,7 @@ convention = 'google'
 #
 # Find all (sub-)modules of the Python package
 [tool.setuptools.packages.find]
+include = ['audiofile*']
 
 # ----- setuptools_scm ----------------------------------------------------
 #


### PR DESCRIPTION
This restricts the files included in the Python package to `audiofile*`.

Same fix as audeering/audb#560 (audeering/audb#559): the empty `[tool.setuptools.packages.find]` defaults to `namespaces = true`, causing setuptools to also pick up `tests/`, `docs/`, `benchmarks/`, and `build/` as top-level namespace packages. They end up installed under `site-packages/` and shadow any local `tests/` or `docs/` packages in downstream projects.