### PR TITLE
CI: exclude gstreamer and scipy from URL checks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -78,6 +78,8 @@ toc_object_entries = False
 linkcheck_ignore = [
     "https://sourceforge.net/projects/mad/",
     "https://sourceforge.net/projects/sox/",
+    "https://gstreamer.freedesktop.org/",
+    "https://docs.scipy.org/",
 ]
 
 # HTML --------------------------------------------------------------------


### PR DESCRIPTION
Exclude gstreamer and scipy docs from URL link checks.