### PR TITLE
CI: update checkout, setup-python, setup-uv, codecov

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -25,6 +25,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        cache-suffix: ${{ github.workflow }}
 
     - name: Ubuntu - install libsndfile
       run: |

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -16,15 +16,15 @@ jobs:
         python-version: [ '3.12' ]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d
+      uses: astral-sh/setup-uv@v9.0.0
 
     - name: Ubuntu - install libsndfile
       run: |

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,6 +21,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        cache-suffix: ${{ github.workflow }}
 
     - name: Install pre-commit hooks
       run: uvx pre-commit install --install-hooks

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,15 +12,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: '3.12'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d
+      uses: astral-sh/setup-uv@v9.0.0
 
     - name: Install pre-commit hooks
       run: uvx pre-commit install --install-hooks

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,15 +16,15 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 2
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: '3.12'
     - name: Install uv
-      uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d
+      uses: astral-sh/setup-uv@v9.0.0
     - name: Prepare Ubuntu
       run: |
         sudo apt-get update

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,8 @@ jobs:
         python-version: '3.12'
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        cache-suffix: ${{ github.workflow }}
     - name: Prepare Ubuntu
       run: |
         sudo apt-get update

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        cache-suffix: ${{ github.workflow }}
 
     - name: Install sox with Micromamba
       run: micromamba install sox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         sox: [ sox, no-sox ]  # sox binary present or not
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Python ${{ matrix.python-version }} with Micromamba
       uses: mamba-org/setup-micromamba@v1
@@ -38,7 +38,7 @@ jobs:
       run: micromamba activate venv
 
     - name: Install uv
-      uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d
+      uses: astral-sh/setup-uv@v9.0.0
 
     - name: Install sox with Micromamba
       run: micromamba install sox
@@ -78,8 +78,8 @@ jobs:
       run: uv run pytest
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
+        files: ./coverage.xml
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/checkout@v7
 
     - name: Set up Python ${{ matrix.python-version }} with Micromamba
-      uses: mamba-org/setup-micromamba@v1
+      uses: mamba-org/setup-micromamba@v3
       with:
         cache-environment: true
         environment-name: venv


### PR DESCRIPTION
## Summary

Two related CI bugs, both caused by stale GitHub Action version pins:

1. **Dead uv caching**: `astral-sh/setup-uv`'s default `cache-dependency-glob`
   keys on `uv.lock`/`requirements*.txt`, neither of which exists here (no
   committed lockfile, by design), so caching never actually worked. This
   repo's `setup-uv` pin was a SHA (`3259c6206f993105e3a61b142c2d97bf4b9ef83d`),
   which resolves to tag `v7.1.0` — already past the fix that matters here
   (`v6.0.0` added `pyproject.toml` to the default glob) and past the Node
   20 -> Node 24 runtime bump (`v7.0.0`). Bumping to `v9.0.0` anyway, for
   consistency with the other repos in this cleanup.

2. **Node.js 20 deprecation**: `actions/checkout` and `actions/setup-python`
   bumped `v4`/`v5` -> `v7`, clearing the "Node.js 20 is deprecated" warning.
   `codecov/codecov-action` bumped `v4` -> `v7`; its `v5` rewrite dropped the
   singular `file:` input in favor of `files:`, renamed accordingly. No
   `actions/cache` usage exists in this repo's workflows.

`prune-cache` left at its new default (off): audiofile's dependency tree
(audeer, audmath, numpy, soundfile) has no large pre-built binary wheels
like torch, so pruning would save ~0 disk space while costing avoidable
re-downloads.

Part of the same CI cleanup as audeering/audeer#206,
audeering/opensmile-python#132, audeering/audb#591,
audeering/audformat#539, audeering/audbackend#307, and
audeering/audresample#83.

## Test plan

- [x] All workflow YAML files reviewed and diff-verified against the
      established pattern from sibling repos
- [ ] CI passes on this PR